### PR TITLE
fix: restrict partition num a multiply of 2

### DIFF
--- a/cmd/create_table.go
+++ b/cmd/create_table.go
@@ -32,8 +32,7 @@ func init() {
 
 Please pay attention to the partition number. It usually depends on the table's on-disk storage size.
 To achieve an predictable performance, you should keep the average partition size within a acceptable
-range.
-	`
+range.`
 
 	shell.AddCommand(&grumble.Command{
 		Name:     "create",

--- a/cmd/create_table.go
+++ b/cmd/create_table.go
@@ -28,15 +28,27 @@ import (
 )
 
 func init() {
+	longHelp := `Create a Pegasus table.
+
+Please pay attention to the partition number. It usually depends on the table's on-disk storage size.
+To achieve an predictable performance, you should keep the average partition size within a acceptable
+range.
+	`
+
 	shell.AddCommand(&grumble.Command{
-		Name:  "create",
-		Help:  "create a table",
-		Usage: "create <table> [-p|--partitions <NUM>] [-r|--replica <NUM>]",
+		Name:     "create",
+		Help:     "create a table",
+		Usage:    "create <table> [-p|--partitions <NUM>] [-r|--replica <NUM>]",
+		LongHelp: longHelp,
 		Run: func(c *grumble.Context) error {
 			if len(c.Args) != 1 {
 				return fmt.Errorf("must specify a table name")
 			}
-			return executor.CreateTable(pegasusClient, c.Args[0], c.Flags.Int("partitions"), c.Flags.Int("replica"))
+			partitionCount := c.Flags.Int("partitions")
+			if partitionCount%2 != 0 {
+				return fmt.Errorf("partitions number must be a multiply of 2")
+			}
+			return executor.CreateTable(pegasusClient, c.Args[0], partitionCount, c.Flags.Int("replica"))
 		},
 		Flags: func(f *grumble.Flags) {
 			f.Int("p", "partitions", 4, "the number of partitions")

--- a/cmd/drop_table.go
+++ b/cmd/drop_table.go
@@ -58,7 +58,7 @@ Documentation:
 		},
 		Flags: func(f *grumble.Flags) {
 			// 7 days by default.
-			f.Duration("r", "reserved", 86400*7, "the soft-deletion period, which is the time before table actually deleted")
+			f.Int64("r", "reserved", 86400*7, "the soft-deletion period, which is the time before table actually deleted")
 		},
 		AllowArgs: true,
 	})


### PR DESCRIPTION
```
Pegasus-AdminCli-1.0.0 » create -p 3 wutao_test
error: partitions number must be a multiply of 2
Pegasus-AdminCli-1.0.0 » create -p 7 wutao_test
error: partitions number must be a multiply of 2
Pegasus-AdminCli-1.0.0 » create -p 8 wutao_test
Creating table "wutao_test" (AppID: 4)
Available partitions:
8 / 8 [------------------------------------------------------------------------------------------------------------------------------] 100.00% 1 p/s 16s
Done!
```