### PR TITLE
fix: print hint of adding duplication

### DIFF
--- a/executor/duplication.go
+++ b/executor/duplication.go
@@ -54,7 +54,9 @@ func AddDuplication(c *Client, tableName string, remoteCluster string, freezed b
 		Freezed:           freezed,
 	})
 	if err != nil {
-		// TODO(wutao): print error hints if it has.
+		if resp != nil && resp.IsSetHint() {
+			return fmt.Errorf("%s\nHint: %s", err, resp.GetHint())
+		}
 		return err
 	}
 	fmt.Fprintf(c, "successfully add duplication [dupid: %d]\n", resp.Dupid)


### PR DESCRIPTION
Previous:
```
Pegasus-AdminCli-1.0.0 » dup add -c onebox2 
error: AddDuplication failed: ErrorCode({Errno:ERR_INVALID_PARAMETERS})
```

Current:
```
Pegasus-AdminCli-1.0.0 » dup add -c onebox2
error: AddDuplication failed: ErrorCode({Errno:ERR_INVALID_PARAMETERS})
Hint: failed to find cluster address in config [pegasus.clusters]
```