### PR TITLE
feat: add dup start command

### DIFF
--- a/cmd/duplication.go
+++ b/cmd/duplication.go
@@ -83,5 +83,18 @@ func init() {
 			f.Int("d", "dupid", -1, "the dupid")
 		},
 	})
+	rootCmd.AddCommand(&grumble.Command{
+		Name: "start",
+		Help: "start a duplication",
+		Run: shell.RequireUseTable(func(c *shell.Context) error {
+			if c.Flags.Int("dupid") == -1 {
+				return fmt.Errorf("dupid cannot be empty")
+			}
+			return executor.ModifyDuplication(pegasusClient, c.UseTable, c.Flags.Int("dupid"), admin.DuplicationStatus_DS_START)
+		}),
+		Flags: func(f *grumble.Flags) {
+			f.Int("d", "dupid", -1, "the dupid")
+		},
+	})
 	shell.AddCommand(rootCmd)
 }

--- a/executor/duplication.go
+++ b/executor/duplication.go
@@ -75,5 +75,6 @@ func ModifyDuplication(c *Client, tableName string, dupid int, status admin.Dupl
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(c, "%s table \"%s\" done [dupid: %d]\n", status, tableName, dupid)
 	return nil
 }


### PR DESCRIPTION
```
Pegasus-AdminCli-1.0.0 » dup pause -d 1610350543
DS_PAUSE table "test" done [dupid: 1610350543]

Pegasus-AdminCli-1.0.0 » dup list 
[
  {
    "dupid": 1610350543,
    "status": "DS_PAUSE",
    "remote": "onebox2",
    "create_ts": 1610350543097,
    "fail_mode": "FAIL_SLOW"
  }
]

Pegasus-AdminCli-1.0.0 » dup start -d 1610350543
DS_START table "test" done [dupid: 1610350543]

Pegasus-AdminCli-1.0.0 » dup list 
[
  {
    "dupid": 1610350543,
    "status": "DS_START",
    "remote": "onebox2",
    "create_ts": 1610350543097,
    "fail_mode": "FAIL_SLOW"
  }
]

```