### PR TITLE
feat: add backup/restore tools

### DIFF
--- a/client/fake_meta_test.go
+++ b/client/fake_meta_test.go
@@ -192,3 +192,16 @@ func findNodeInFakeCluster(pn *util.PegasusNode) *fakeNode {
 	}
 	return ret
 }
+
+func StartBackupApp(tableID int, providerType string, backupPath string) (*admin.StartBackupAppResponse, error) {
+	panic("unimplemented")
+}
+
+func QueryBackupStatus(tableID int, backupID int64) (*admin.QueryBackupStatusResponse, error) {
+	panic("unimplemented")
+}
+
+func RestoreApp(oldClusterName string, oldTableName string, oldTableID int, backupID int64, providerType string,
+	newTableName string, restorePath string, skipBadPartition bool, policyName string) (*admin.CreateAppResponse, error) {
+	panic("unimplemented")
+}

--- a/client/fake_meta_test.go
+++ b/client/fake_meta_test.go
@@ -193,15 +193,15 @@ func findNodeInFakeCluster(pn *util.PegasusNode) *fakeNode {
 	return ret
 }
 
-func StartBackupApp(tableID int, providerType string, backupPath string) (*admin.StartBackupAppResponse, error) {
+func (m *fakeMeta) StartBackupApp(tableID int, providerType string, backupPath string) (*admin.StartBackupAppResponse, error) {
 	panic("unimplemented")
 }
 
-func QueryBackupStatus(tableID int, backupID int64) (*admin.QueryBackupStatusResponse, error) {
+func (m *fakeMeta) QueryBackupStatus(tableID int, backupID int64) (*admin.QueryBackupStatusResponse, error) {
 	panic("unimplemented")
 }
 
-func RestoreApp(oldClusterName string, oldTableName string, oldTableID int, backupID int64, providerType string,
+func (m *fakeMeta) RestoreApp(oldClusterName string, oldTableName string, oldTableID int, backupID int64, providerType string,
 	newTableName string, restorePath string, skipBadPartition bool, policyName string) (*admin.CreateAppResponse, error) {
 	panic("unimplemented")
 }

--- a/cmd/backup_restore.go
+++ b/cmd/backup_restore.go
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/desertbit/grumble"
+	"github.com/pegasus-kv/admin-cli/executor"
+	"github.com/pegasus-kv/admin-cli/shell"
+)
+
+func init() {
+
+	shell.AddCommand(&grumble.Command{
+		Name:  "backup",
+		Help:  "backup a table",
+		Usage: "backup <TABLE_ID> <PROVIDER_TYPE> [SPECIFIC_BACKUP_PATH]",
+
+		Args: func(a *grumble.Args) {
+			a.Int("tableID", "the table ID")
+			a.String("providerType", "the provider type of backup")
+			a.String("backupPath", "the user specified backup path", grumble.Default(""))
+		},
+		Run: func(c *grumble.Context) error {
+			tableID := c.Args.Int("tableID")
+			providerType := c.Args.String("providerType")
+			backupPath := c.Args.String("backupPath")
+			return executor.BackupTable(pegasusClient, tableID, providerType, backupPath)
+		},
+	})
+
+	shell.AddCommand(&grumble.Command{
+		Name:  "query-backup-status",
+		Help:  "query backup status",
+		Usage: "query-backup-status <TABLE_ID> [BACKUP_ID]",
+		Args: func(a *grumble.Args) {
+			a.Int("tableID", "the table ID")
+			a.Int64("backupID", "the backup ID", grumble.Default(int64(0)))
+		},
+		Run: func(c *grumble.Context) error {
+			tableID := c.Args.Int("tableID")
+			backupID := c.Args.Int64("backupID")
+			return executor.QueryBackupStatus(pegasusClient, tableID, backupID)
+		},
+	})
+
+	shell.AddCommand(&grumble.Command{
+		Name: "restore",
+		Help: "restore a table",
+		Usage: `restore 
+		<-c|--oldClusterName OLD_CLUSTER_NAME> 
+		<-a|--oldTableName OLD_TABLE_NAME> 
+		<-i|--oldTableID OLD_TABLE_ID>
+		<-t|--timestamp TIMESTAMP/BACKUP_ID>
+		<-b|--providerType PROVIDER_TYPE>
+		[-n|--newTableName NEW_TABLE_NAME]
+		[-r|--restorePath SPECIFIC_RESTORE_PATH]
+		[-s|--skipBadPartition SKIP_BAD_PARTITION]
+		[-p|--policyName POLICY_NAME]`,
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("oldClusterName") == "" {
+				return fmt.Errorf("oldClusterName cannot be empty")
+			}
+			if c.Flags.String("oldTableName") == "" {
+				return fmt.Errorf("oldTableName cannot be empty")
+			}
+			if c.Flags.Int("oldTableID") == 0 {
+				return fmt.Errorf("oldTableID cannot be empty")
+			}
+			if c.Flags.Int64("timestamp") == 0 {
+				return fmt.Errorf("timestamp cannot be empty")
+			}
+			if c.Flags.String("providerType") == "" {
+				return fmt.Errorf("providerType cannot be empty")
+			}
+			var newName string
+			if c.Flags.String("newTableName") == "" {
+				newName = c.Flags.String("oldTableName")
+			} else {
+				newName = c.Flags.String("newTableName")
+			}
+			oldClusterName := c.Flags.String("oldClusterName")
+			oldTableName := c.Flags.String("oldTableName")
+			oldTableID := c.Flags.Int("oldTableID")
+			backupID := c.Flags.Int64("timestamp")
+			providerType := c.Flags.String("providerType")
+			newTableName := newName
+			restorePath := c.Flags.String("restorePath")
+			skipBadPartition := c.Flags.Bool("skipBadPartition")
+			policyName := c.Flags.String("policyName")
+			return executor.RestoreTable(pegasusClient, oldClusterName, oldTableName,
+				oldTableID, backupID, providerType, newTableName, restorePath, skipBadPartition, policyName)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("c", "oldClusterName", "", "old_cluster_name, for example, onebox")
+			f.String("a", "oldTableName", "", "old_app_name, for example, temp")
+			f.Int("i", "oldTableID", 0, "old_app_id, for example, 1")
+			f.Int64("t", "timestamp", 0, "timestamp or backup_id")
+			f.String("b", "providerType", "", "backup_provider_type, for example, hdfs_zjy")
+			f.String("n", "newTableName", "", "new_app_name")
+			f.String("r", "restorePath", "", "restore_path")
+			f.Bool("s", "skipBadPartition", false, "whether to skip bad partition when create new table")
+			f.String("p", "policyName", "", "old_policy_name, only worked for restoring app created before Pegasus2.2.0")
+		},
+	})
+}

--- a/executor/backup_restore.go
+++ b/executor/backup_restore.go
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/XiaoMi/pegasus-go-client/idl/base"
+	"github.com/pegasus-kv/admin-cli/tabular"
+)
+
+func BackupTable(client *Client, tableID int, providerType string, backupPath string) error {
+	resp, errRecall := client.Meta.StartBackupApp(tableID, providerType, backupPath)
+	if errRecall != nil {
+		return errRecall
+	}
+	fmt.Printf("[hint]: %s\n", resp.GetHintMessage())
+	fmt.Printf("BackupID: %d\n", resp.GetBackupID())
+	return nil
+}
+
+func QueryBackupStatus(client *Client, tableID int, backupID int64) error {
+	resp, errRecall := client.Meta.QueryBackupStatus(tableID, backupID)
+	if errRecall != nil {
+		return errRecall
+	}
+	fmt.Printf("[hint]: %s\n", resp.GetHintMessage())
+
+	type backupItemStruct struct {
+		BackupID           int64  `json:"BackupID"`
+		AppName            string `json:"AppName"`
+		StartTime          string `json:"StartTime"`
+		EndTime            string `json:"EndTime"`
+		Status             string `json:"Status"`
+		BackupProviderType string `json:"BackupProviderType"`
+		BackupPath         string `json:"BackupPath"`
+	}
+
+	var tbList []interface{}
+	for _, item := range resp.GetBackupItems() {
+		var status string
+		if item.IsBackupFailed {
+			status = "failed"
+		} else if item.EndTimeMs == 0 {
+			status = "in progress"
+		} else {
+			status = "completed"
+		}
+
+		startTime := time.Unix(item.StartTimeMs/1000, 0).String()
+		var endTime string
+		if item.EndTimeMs == 0 {
+			endTime = "-"
+		} else {
+			endTime = time.Unix(item.EndTimeMs/1000, 0).String()
+		}
+
+		tbList = append(tbList, backupItemStruct{
+			BackupID:           item.BackupID,
+			AppName:            item.AppName,
+			StartTime:          startTime,
+			EndTime:            endTime,
+			Status:             status,
+			BackupProviderType: item.BackupProviderType,
+			BackupPath:         item.BackupPath,
+		})
+	}
+	// formats into tabular
+	tabular.Print(client, tbList)
+	return nil
+}
+
+func RestoreTable(client *Client, oldClusterName string, oldTableName string, oldTableID int,
+	backupID int64, providerType string, newTableName string, restorePath string, skipBadPartition bool, policyName string) error {
+	resp, errRecall := client.Meta.RestoreApp(
+		oldClusterName, oldTableName, oldTableID, backupID, providerType, newTableName, restorePath, skipBadPartition, policyName)
+	if errRecall != nil {
+		return errRecall
+	}
+
+	fmt.Fprintf(client, "new AppID: %d\n", resp.GetAppid())
+	errWait := waitTableBecomeHealthy(client, newTableName)
+
+	if errWait != nil {
+		return errWait
+	}
+
+	return nil
+}
+
+func waitTableBecomeHealthy(c *Client, tableName string) error {
+	fmt.Fprintf(c, "Wait table \"%s\" become healthy ...\n", tableName)
+	resp, err := c.Meta.QueryConfig(tableName)
+	if err != nil {
+		return err
+	}
+	if resp.GetErr().Errno != base.ERR_OK.String() {
+		return fmt.Errorf("QueryConfig failed: %s", resp.GetErr().String())
+	}
+
+	partitionCount := resp.PartitionCount
+	var replicaCount int32
+	replicaCount = 0
+	for _, part := range resp.Partitions {
+		maxReplicaCount := part.GetMaxReplicaCount()
+		if maxReplicaCount > replicaCount {
+			replicaCount = maxReplicaCount
+		}
+	}
+	return waitTableReady(c, tableName, int(partitionCount), int(replicaCount))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pegasus-kv/admin-cli
 go 1.14
 
 require (
-	github.com/XiaoMi/pegasus-go-client v0.0.0-20210427083443-f3b6b08bc4c2
+	github.com/XiaoMi/pegasus-go-client v0.0.0-20210508064509-3af6e8b3c3c4
 	github.com/cheggaaa/pb/v3 v3.0.6
 	github.com/desertbit/grumble v1.1.1
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -32,9 +32,11 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/XiaoMi/pegasus-go-client v0.0.0-20201127155445-d3b9a03abf6e/go.mod h1:H83dStz3HvHBFC0n7QK+qLHAjqsIghFOFx2TCvq6vzI=
-github.com/XiaoMi/pegasus-go-client v0.0.0-20210427083443-f3b6b08bc4c2 h1:pami0oPhVosjOu/qRHepRmdjD6hGILF7DBr+qQZeP10=
-github.com/XiaoMi/pegasus-go-client v0.0.0-20210427083443-f3b6b08bc4c2/go.mod h1:jNIx5ykW1MroBuaTja9+VpglmaJOUzezumfhLlER3oY=
+github.com/XiaoMi/pegasus-go-client v0.0.0-20210508064509-3af6e8b3c3c4 h1:Wa2/gHZqf+1tcYQWOGpjMEP2iyelc//X9F43bVrS7/w=
+github.com/XiaoMi/pegasus-go-client v0.0.0-20210508064509-3af6e8b3c3c4/go.mod h1:VrfgKISflRhFm32m3e0SXLccvNJTyG8PRywWbUuGEfY=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
+github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
I tested it in onebox cluster.

`backup` tool :
```
Pegasus-AdminCli-1.0.0 » backup 2 local_service
[hint]: Backup succeed: metadata of app 2 has been successfully backed up and backup request has been sent to replica servers.
BackupID: 1620458647651
```
`query-backup-status` tool:
```
Pegasus-AdminCli-1.0.0 » query-backup-status 2
[hint]: There are 1 available backups for app 2.
+---------------+---------+-------------------------------+-------------------------------+-----------+--------------------+------------+
|   BackupID    | AppName |           StartTime           |            EndTime            |  Status   | BackupProviderType | BackupPath |
+---------------+---------+-------------------------------+-------------------------------+-----------+--------------------+------------+
| 1620458647651 | temp    | 2021-05-08 15:24:07 +0800 CST | 2021-05-08 15:24:30 +0800 CST | completed | local_service      |            |
+---------------+---------+-------------------------------+-------------------------------+-----------+--------------------+------------+
```
`restore` tool:
```
Pegasus-AdminCli-1.0.0 » restore -c onebox -a temp -i 2 -t 1620458647651 -b local_service -n restore_temp
new AppID: 16
Wait table "restore_temp" become healthy ...
Available partitions:
8 / 8 [-------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1 p/s 13s
Done!
Pegasus-AdminCli-1.0.0 » ls
+----+----------------+------------+-----------+----------------+---------------+------------+---------------+-----------------+
| ID |      Name      | Partitions | Unhealthy | WriteUnhealthy | ReadUnhealthy | CreateTime | WReqRateLimit | WBytesRateLimit |
+----+----------------+------------+-----------+----------------+---------------+------------+---------------+-----------------+
| 1  | stat           | 4          | 0         | 0              | 0             | 2021-04-28 |               |                 |
| 2  | temp           | 8          | 0         | 0              | 0             | 2021-04-28 |               |                 |
| 3  | table          | 4          | 0         | 0              | 0             | 2021-04-29 |               |                 |
| 15 | restore_temp_1 | 8          | 0         | 0              | 0             | 2021-04-28 |               |                 |
| 16 | restore_temp   | 8          | 0         | 0              | 0             | 2021-04-28 |               |                 |
+----+----------------+------------+-----------+----------------+---------------+------------+---------------+-----------------+

```