### PR TITLE
feat(disk-balance):  init framework for adding disk balance automatically(1/3)

### DIFF
--- a/cmd/disk_balance.go
+++ b/cmd/disk_balance.go
@@ -53,9 +53,10 @@ func init() {
 		Help: "auto-migrate replica to let the disks space balance within the given ReplicaServer",
 		Flags: func(f *grumble.Flags) {
 			f.String("n", "node", "", "target node, for example, 127.0.0.1:34801")
+			f.Bool("a", "auto", false, "auto balance node until the the node is balanced")
 		},
 		Run: func(c *grumble.Context) error {
-			return executor.DiskBalance(pegasusClient, c.Flags.String("node"))
+			return executor.DiskBalance(pegasusClient, c.Flags.String("node"), c.Flags.Bool("auto"))
 		},
 	})
 

--- a/cmd/disk_balance.go
+++ b/cmd/disk_balance.go
@@ -53,7 +53,7 @@ func init() {
 		Help: "auto-migrate replica to let the disks space balance within the given ReplicaServer",
 		Flags: func(f *grumble.Flags) {
 			f.String("n", "node", "", "target node, for example, 127.0.0.1:34801")
-			f.Int64("s", "size", 10<<10, "allow migrate min replica size")
+			f.Int64("s", "size", 10<<10, "allow migrate min replica size, default 10GB")
 			f.Bool("a", "auto", false, "auto balance node until the the node is balanced")
 		},
 		Run: func(c *grumble.Context) error {

--- a/cmd/disk_balance.go
+++ b/cmd/disk_balance.go
@@ -53,10 +53,11 @@ func init() {
 		Help: "auto-migrate replica to let the disks space balance within the given ReplicaServer",
 		Flags: func(f *grumble.Flags) {
 			f.String("n", "node", "", "target node, for example, 127.0.0.1:34801")
+			f.Int64("s", "size", 10<<10, "allow migrate min replica size")
 			f.Bool("a", "auto", false, "auto balance node until the the node is balanced")
 		},
 		Run: func(c *grumble.Context) error {
-			return executor.DiskBalance(pegasusClient, c.Flags.String("node"), c.Flags.Bool("auto"))
+			return executor.DiskBalance(pegasusClient, c.Flags.String("node"), c.Flags.Int64("size"), c.Flags.Bool("auto"))
 		},
 	})
 

--- a/cmd/disk_info.go
+++ b/cmd/disk_info.go
@@ -37,13 +37,12 @@ func init() {
 			f.String("t", "table", "", "table name, for example, temp")
 		},
 		Run: func(c *grumble.Context) error {
-			_, err := executor.QueryDiskInfo(
+			return executor.QueryDiskInfo(
 				pegasusClient,
 				executor.CapacitySize,
 				c.Flags.String("node"),
 				c.Flags.String("table"),
 				c.Flags.String("disk"))
-			return err
 		},
 	})
 
@@ -56,13 +55,12 @@ func init() {
 			f.String("t", "table", "", "table name, for example, temp")
 		},
 		Run: func(c *grumble.Context) error {
-			_, err := executor.QueryDiskInfo(
+			return executor.QueryDiskInfo(
 				pegasusClient,
 				executor.ReplicaCount,
 				c.Flags.String("node"),
 				c.Flags.String("table"),
 				"")
-			return err
 		},
 	})
 }

--- a/executor/create_table.go
+++ b/executor/create_table.go
@@ -47,7 +47,7 @@ func CreateTable(c *Client, tableName string, partitionCount int, replicaCount i
 }
 
 func waitTableReady(c *Client, tableName string, partitionCount int, replicaCount int) error {
-	fmt.Fprintf(c, "Usage partitions:\n")
+	fmt.Fprintf(c, "Available partitions:\n")
 	bar := pb.Full.Start(partitionCount) // Add a new bar
 
 	for {

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -288,7 +288,8 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
 	if selectReplica.Size < (10 << 10) {
-		return nil, fmt.Errorf("not suggest balance: the size is too small, size=%dMB", selectReplica.Size)
+		return nil, fmt.Errorf("not suggest balance: the replica(%s) size is too small, replica size=%dMB, sizeToMove=%dMB",
+			selectReplica.Gpid, selectReplica.Size, sizeToMove)
 	}
 
 	fmt.Printf("disk migrate(sizeToMove=%dMB): node=%s, from=%s, to=%s, gpid=%s(size=%dMB)\n",

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -174,7 +174,7 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 		migrateDisk.HighDisk.NodeCapacity.Disk,
 		migrateDisk.LowDisk.NodeCapacity.Disk,
 		selectReplica.Replica,
-		selectReplica.Size)
+		int64(selectReplica.Size))
 	return &MigrateAction{
 		node: replicaServer,
 		gpid: selectReplica.Replica,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -74,7 +74,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 			if err != nil {
 				return err
 			}
-			time.Sleep(time.Second * 5)
+			time.Sleep(time.Second * 10)
 			continue
 		}
 		err = DiskMigrate(client, replicaServer, action.replica.Gpid, action.from, action.to)
@@ -84,7 +84,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 		if !auto {
 			break
 		}
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 30)
 	}
 	fmt.Printf("balance succeed!")
 	return nil
@@ -127,7 +127,7 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 }
 
 func forceAssignReplicaToSecondary(client *Client, replicaServer string, gpid string) error {
-	fmt.Printf("WARNING: the select replica is not secondary, will force assign it secondary")
+	fmt.Printf("WARNING: the select replica is not secondary, will force assign it secondary\n")
 	_, err := client.Meta.MetaControl(admin.MetaFunctionLevel_fl_steady)
 	if err != nil {
 		return err
@@ -292,10 +292,11 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 			selectReplica.Gpid, selectReplica.Size, sizeToMove)
 	}
 
-	fmt.Printf("disk migrate(sizeToMove=%dMB): node=%s, from=%s, to=%s, gpid=%s(size=%dMB)\n",
+	fmt.Printf("disk migrate(sizeToMove=%dMB): node=%s, from=%s, to=%s, gpid(%s)=%s(size=%dMB)\n",
 		sizeToMove, migrate.currentNode,
 		migrate.HighDisk.NodeCapacity.Disk,
 		migrate.LowDisk.NodeCapacity.Disk,
+		selectReplica.Status,
 		selectReplica.Gpid,
 		selectReplica.Size)
 

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -105,7 +105,7 @@ func DiskBalance(client *Client, replicaServer string, minSize int64, auto bool)
 					time.Sleep(time.Second * 10)
 					continue
 				}
-				fmt.Printf("migrate(%s) is completed，result=%s\n\n", action.toString(), err.Error())
+				fmt.Printf("migrate(%s) is completed，result=%s, wait disk cleaner remove garbage...\n\n", action.toString(), err.Error())
 				break
 			}
 			time.Sleep(time.Second * 90)

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -278,12 +278,11 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 
 	averageUsage := totalUsage / int64(len(disks))
 	averageRatio := totalUsage * 100 / totalCapacity
-	if highUsageDisk.Ratio-averageRatio < 5 {
+	if highUsageDisk.Ratio-lowUsageDisk.Ratio < 10 {
 		return nil, fmt.Errorf("no need balance for the disk is balanced:"+
-			" high(%s): %dMB(%d%%); low(%s): %dMB(%d%%); average: %dMB(%d%%), balance delta=%d%%)",
+			" high(%s): %dMB(%d%%); low(%s): %dMB(%d%%); average: %dMB(%d%%)",
 			highUsageDisk.Disk, highUsageDisk.Usage, highUsageDisk.Ratio, lowUsageDisk.Disk,
-			lowUsageDisk.Usage, lowUsageDisk.Ratio, averageUsage, totalUsage*100/totalCapacity,
-			highUsageDisk.Ratio-averageRatio)
+			lowUsageDisk.Usage, lowUsageDisk.Ratio, averageUsage, averageRatio)
 	}
 
 	replicaCapacityOnHighDisk, err := convertReplicaCapacityStruct(highDiskInfo)

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -339,8 +339,8 @@ func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, 
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
 	if selectReplica.Size < minSize {
-		return nil, fmt.Errorf("not suggest balance(%s): the selected replica size(%s=%dMB) is too small(must >=%dMB), sizeNeedMove=%dMB",
-			migrate.toString(), selectReplica.Gpid, selectReplica.Size, minSize, sizeNeedMove)
+		return nil, fmt.Errorf("not suggest balance(%s): the qualified(must<=sizeNeedMove(%dMB)) replica size(%s=%dMB) is too small(must>=minSize(%dMB))",
+			migrate.toString(), sizeNeedMove, selectReplica.Gpid, selectReplica.Size, minSize)
 	}
 
 	fmt.Printf("ACTION:disk migrate(sizeNeedMove=%dMB): %s, gpid(%s)=%s(%dMB)\n",

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -294,11 +294,11 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 
 	replicaCapacityOnHighDisk, err := convertReplicaCapacityStruct(highDiskInfo)
 	if err != nil { // we need migrate replica from high disk, so the convert must be successful
-		return nil, fmt.Errorf("convert replica on high disk(%s) failed: %s", highUsageDisk.Disk, err.Error())
+		return nil, fmt.Errorf("parse replica info on high disk(%s) failed: %s", highUsageDisk.Disk, err.Error())
 	}
 	replicaCapacityOnLowDisk, err := convertReplicaCapacityStruct(lowDiskInfo)
 	if err != nil { // we don't care the replica capacity info on low disk, if convert failed, we only log warning and know the result=nil
-		fmt.Printf("WARNING: convert replica on low disk(%s) failed: %s", lowUsageDisk.Disk, err.Error())
+		fmt.Printf("WARNING: parse replica info on low disk(%s) failed: %s", lowUsageDisk.Disk, err.Error())
 	}
 	return &MigrateDisk{
 		AverageUsage: averageUsage,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -93,11 +93,6 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 		if err == nil {
 			fmt.Printf("migrate(%s from %s to %s) has started, wait complete...\n",
 				action.replica.Gpid, action.from, action.to)
-			time.Sleep(time.Second * 90)
-			continue
-		}
-		if strings.Contains(err.Error(), "ERR_BUSY") {
-			time.Sleep(time.Second * 10)
 			for {
 				// TODO(jiashuo1): using DiskMigrate RPC to query status, consider support queryDiskMigrateStatus RPC
 				err = DiskMigrate(client, replicaServer, action.replica.Gpid, action.from, action.to)
@@ -116,6 +111,8 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 					action.replica.Gpid, action.from, action.to, err.Error())
 				break
 			}
+			time.Sleep(time.Second * 90)
+			continue
 		}
 		if auto {
 			time.Sleep(time.Second * 90)

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -175,6 +175,7 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 		migrateDisk.LowDisk.NodeCapacity.Disk,
 		selectReplica.Replica,
 		int64(selectReplica.Size))
+
 	return &MigrateAction{
 		node: replicaServer,
 		gpid: selectReplica.Replica,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -133,7 +133,7 @@ type MigrateDisk struct {
 }
 
 func (m *MigrateDisk) toString() string {
-	return fmt.Sprintf("Node=%s, HighDisk=%s[%dMB(%d%%)], LowDisk=%s[%dMB(%d%%)]", m.currentNode,
+	return fmt.Sprintf("Node=%s, HighDisk=%s[%dMB(%d%%)]=>LowDisk=%s[%dMB(%d%%)]", m.currentNode,
 		m.HighDisk.DiskCapacity.Disk, m.HighDisk.DiskCapacity.Usage, m.HighDisk.DiskCapacity.Ratio,
 		m.LowDisk.DiskCapacity.Disk, m.LowDisk.DiskCapacity.Usage, m.LowDisk.DiskCapacity.Ratio)
 }
@@ -339,7 +339,7 @@ func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, 
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
 	if selectReplica.Size < minSize {
-		return nil, fmt.Errorf("not suggest balance(%s): the replica size(%s=%dMB) is too small(must >=%dMB), sizeNeedMove=%dMB",
+		return nil, fmt.Errorf("not suggest balance(%s): the selected replica size(%s=%dMB) is too small(must >=%dMB), sizeNeedMove=%dMB",
 			migrate.toString(), selectReplica.Gpid, selectReplica.Size, minSize, sizeNeedMove)
 	}
 

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -294,7 +294,6 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 
 	var selectReplica *ReplicaCapacityStruct
 	for i := len(migrate.HighDisk.ReplicaCapacity) - 1; i >= 0; i-- {
-		fmt.Printf("%s:%d", migrate.HighDisk.ReplicaCapacity[i].Gpid , migrate.HighDisk.ReplicaCapacity[i].Size)
 		if migrate.HighDisk.ReplicaCapacity[i].Size > sizeToMove {
 			continue
 		} else {

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -330,7 +330,7 @@ func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, 
 	}
 
 	if selectReplica == nil {
-		return nil, fmt.Errorf("can't balance(%s): sizeNeedMove=%dMB, but the min replica(%s) size is %dMB on high disk",
+		return nil, fmt.Errorf("can't balance(%s): sizeNeedMove=%dMB, but the min replica(%s) size is %dMB on high disk(min size must <= sizeNeedMove)",
 			migrate.toString(),
 			sizeNeedMove,
 			migrate.HighDisk.ReplicaCapacity[0].Gpid,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -279,7 +279,7 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 	averageUsage := totalUsage / int64(len(disks))
 	averageRatio := totalUsage * 100 / totalCapacity
 	if highUsageDisk.Ratio-lowUsageDisk.Ratio < 5 {
-		return nil, fmt.Errorf("no need balance for the disk is balanced:"+
+		return nil, fmt.Errorf("no need balance since the disk is balanced:"+
 			" high(%s): %dMB(%d%%); low(%s): %dMB(%d%%); average: %dMB(%d%%)",
 			highUsageDisk.Disk, highUsageDisk.Usage, highUsageDisk.Ratio, lowUsageDisk.Disk,
 			lowUsageDisk.Usage, lowUsageDisk.Ratio, averageUsage, averageRatio)

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -107,7 +107,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 					time.Sleep(time.Second * 10)
 					continue
 				}
-				fmt.Printf("migrate(%s: %s => %s) is completed， result=%s",
+				fmt.Printf("migrate(%s: %s => %s) is completed， result=%s\n",
 					action.replica.Gpid, action.from, action.to, err.Error())
 				break
 			}

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -293,7 +293,8 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 	sizeToMove := int64(math.Min(float64(lowDiskCanReceiveMax), float64(highDiskCanSendMax)))
 
 	var selectReplica *ReplicaCapacityStruct
-	for i := len(migrate.HighDisk.ReplicaCapacity) - 1; i > 0; i-- {
+	for i := len(migrate.HighDisk.ReplicaCapacity) - 1; i >= 0; i-- {
+		fmt.Printf("%s:%d", migrate.HighDisk.ReplicaCapacity[i].Gpid , migrate.HighDisk.ReplicaCapacity[i].Size)
 		if migrate.HighDisk.ReplicaCapacity[i].Size > sizeToMove {
 			continue
 		} else {

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -79,6 +79,8 @@ type DiskStats struct {
 }
 
 func getCurrentDiskStats(client *Client, replicaServer string) (*DiskStats, error) {
+
+	fmt.Println("[Node Capacity]")
 	diskCapacityOnNode, err := QueryDiskInfo(client, CapacitySize, replicaServer, "", "")
 	if err != nil {
 		return nil, err
@@ -104,11 +106,13 @@ func getCurrentDiskStats(client *Client, replicaServer string) (*DiskStats, erro
 	averageUsage := totalUsage / int64(len(disks))
 
 	highUsageDisk := disks[len(disks)-1]
+	fmt.Printf("[High Disk(%s)]\n", highUsageDisk.Disk)
 	highDiskInfo, err := QueryDiskInfo(client, CapacitySize, replicaServer, "", highUsageDisk.Disk)
 	if err != nil {
 		return nil, err
 	}
 	lowUsageDisk := disks[0]
+	fmt.Printf("[Low Disk(%s)]\n", lowUsageDisk.Disk)
 	lowDiskInfo, err := QueryDiskInfo(client, CapacitySize, replicaServer, "", lowUsageDisk.Disk)
 	if err != nil {
 		return nil, err

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -129,11 +129,7 @@ type MigrateAction struct {
 }
 
 func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterval int64) error {
-	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_tmp_replica_interval_seconds", "set", cleanInterval)
-	if err != nil {
-		return err
-	}
-	err = ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
+	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
 	if err != nil {
 		return err
 	}

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -330,16 +330,16 @@ func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, 
 	}
 
 	if selectReplica == nil {
-		return nil, fmt.Errorf("can't balance(%s): sizeNeedMove=%dMB, but the min replica(%s) size is %dMB on high disk(min size must <= sizeNeedMove)",
+		return nil, fmt.Errorf("can't balance(%s): high disk min replica(%s) size(%dMB) must <= sizeNeedMove(%dMB)",
 			migrate.toString(),
-			sizeNeedMove,
 			migrate.HighDisk.ReplicaCapacity[0].Gpid,
-			migrate.HighDisk.ReplicaCapacity[0].Size)
+			migrate.HighDisk.ReplicaCapacity[0].Size,
+			sizeNeedMove)
 	}
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
 	if selectReplica.Size < minSize {
-		return nil, fmt.Errorf("not suggest balance(%s): the qualified(must<=sizeNeedMove(%dMB)) replica size(%s=%dMB) is too small(must>=minSize(%dMB))",
+		return nil, fmt.Errorf("not suggest balance(%s): the qualified(must<=sizeNeedMove(%dMB)) replica size(%s=%dMB) must >= minSize(%dMB))",
 			migrate.toString(), sizeNeedMove, selectReplica.Gpid, selectReplica.Size, minSize)
 	}
 

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -107,7 +107,7 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 
 func queryDiskCapacityInfo(client *Client, replicaServer string) ([]NodeCapacityStruct, int64, int64, error) {
 	fmt.Println("[Node Capacity]")
-	diskCapacityOnNode, err := QueryDiskInfo(client, CapacitySize, replicaServer, "", "")
+	diskCapacityOnNode, err := queryDiskInfo(client, CapacitySize, replicaServer, "", "", false)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -137,14 +137,12 @@ func queryDiskCapacityInfo(client *Client, replicaServer string) ([]NodeCapacity
 
 func getMigrateDiskInfo(client *Client, replicaServer string, disks []NodeCapacityStruct, totalUsage int64, totalCapacity int64) (*MigrateDisk, error) {
 	highUsageDisk := disks[len(disks)-1]
-	fmt.Printf("[High Disk(%s)]\n", highUsageDisk.Disk)
-	highDiskInfo, err := QueryDiskInfo(client, CapacitySize, replicaServer, "", highUsageDisk.Disk)
+	highDiskInfo, err := queryDiskInfo(client, CapacitySize, replicaServer, "", highUsageDisk.Disk, false)
 	if err != nil {
 		return nil, err
 	}
 	lowUsageDisk := disks[0]
-	fmt.Printf("[Low Disk(%s)]\n", lowUsageDisk.Disk)
-	lowDiskInfo, err := QueryDiskInfo(client, CapacitySize, replicaServer, "", lowUsageDisk.Disk)
+	lowDiskInfo, err := queryDiskInfo(client, CapacitySize, replicaServer, "", lowUsageDisk.Disk, false)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -128,6 +128,10 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 
 func forceAssignReplicaToSecondary(client *Client, replicaServer string, gpid string) error {
 	fmt.Printf("WARNING: the select replica is not secondary, will force assign it secondary")
+	_, err := client.Meta.MetaControl(admin.MetaFunctionLevel_fl_steady)
+	if err != nil {
+		return err
+	}
 	secondaryNode, err := getReplicaSecondaryNode(client, gpid)
 	if err != nil {
 		return err

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -330,7 +330,7 @@ func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, 
 	}
 
 	if selectReplica == nil {
-		return nil, fmt.Errorf("can't balance(%s): sizeNeedMove=%dMB,but the min replica(%s) size is %dMB on high disk",
+		return nil, fmt.Errorf("can't balance(%s): sizeNeedMove=%dMB, but the min replica(%s) size is %dMB on high disk",
 			migrate.toString(),
 			sizeNeedMove,
 			migrate.HighDisk.ReplicaCapacity[0].Gpid,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -69,6 +69,13 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = changeDiskCleanerInterval(client, replicaServer, 86400)
+		if err != nil {
+			fmt.Println("revert disk cleaner failed")
+		}
+	}()
+
 	for {
 		action, err := getNextMigrateAction(client, replicaServer)
 		if err != nil {
@@ -105,7 +112,8 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 					time.Sleep(time.Second * 10)
 					continue
 				}
-				fmt.Printf("migrate(%s from %s to %s) is completed， result=%s", action.replica.Gpid, action.from, action.to, err.Error())
+				fmt.Printf("migrate(%s from %s to %s) is completed， result=%s",
+					action.replica.Gpid, action.from, action.to, err.Error())
 				break
 			}
 		}
@@ -114,10 +122,6 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 			continue
 		}
 		break
-	}
-	err = changeDiskCleanerInterval(client, replicaServer, 86400)
-	if err != nil {
-		return err
 	}
 	return nil
 }

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -143,7 +143,7 @@ type MigrateAction struct {
 }
 
 func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterval int64) error {
-	fmt.Printf("set gc_disk_migration_origin_replica_interval_seconds = %ds ",  cleanInterval)
+	fmt.Printf("set gc_disk_migration_origin_replica_interval_seconds = %ds ", cleanInterval)
 	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
 	if err != nil {
 		return err

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -83,15 +83,21 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 			continue
 		}
 		err = DiskMigrate(client, replicaServer, action.replica.Gpid, action.from, action.to)
-		if err == nil || strings.Contains(err.Error(), "ERR_BUSY") {
-			fmt.Printf("migrate(%s from %s to %s) is running, msg=%s, try again",
-				action.replica.Gpid, action.from, action.to, err)
-			time.Sleep(time.Second * 30)
+		if err == nil {
+			fmt.Printf("migrate(%s from %s to %s) has started, wait complete...\n",
+				action.replica.Gpid, action.from, action.to)
+			time.Sleep(time.Second * 90)
+			continue
+		}
+		if strings.Contains(err.Error(), "ERR_BUSY") {
+			fmt.Printf("migrate(%s from %s to %s) is running, msg=%s, wait complete...\n",
+				action.replica.Gpid, action.from, action.to, err.Error())
+			time.Sleep(time.Second * 90)
 			continue
 		}
 		fmt.Printf("migrate(%s from %s to %s) is completed", action.replica.Gpid, action.from, action.to)
 		if auto {
-			time.Sleep(time.Second * 60)
+			time.Sleep(time.Second * 90)
 			continue
 		}
 		break

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -95,7 +95,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 			time.Sleep(time.Second * 90)
 			continue
 		}
-		fmt.Printf("migrate(%s from %s to %s) is completed", action.replica.Gpid, action.from, action.to)
+		fmt.Printf("migrate(%s from %s to %s) is completed， result=%s", action.replica.Gpid, action.from, action.to, err.Error())
 		if auto {
 			time.Sleep(time.Second * 90)
 			continue

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -293,7 +293,7 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 	sizeToMove := int64(math.Min(float64(lowDiskCanReceiveMax), float64(highDiskCanSendMax)))
 
 	var selectReplica *ReplicaCapacityStruct
-	for i := len(migrate.HighDisk.ReplicaCapacity) - 1; i > 0; i++ {
+	for i := len(migrate.HighDisk.ReplicaCapacity) - 1; i > 0; i-- {
 		if migrate.HighDisk.ReplicaCapacity[i].Size > sizeToMove {
 			continue
 		} else {

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/XiaoMi/pegasus-go-client/idl/base"
 	"github.com/XiaoMi/pegasus-go-client/idl/radmin"
 	"github.com/XiaoMi/pegasus-go-client/session"
 	"github.com/pegasus-kv/admin-cli/util"
@@ -76,8 +77,7 @@ func DiskBalance(client *Client, replicaServer string, minSize int64, auto bool)
 		return err
 	}
 	defer func() {
-		err = changeDiskCleanerInterval(client, replicaServer, 86400)
-		if err != nil {
+		if err = changeDiskCleanerInterval(client, replicaServer, 86400); err != nil {
 			fmt.Println("revert disk cleaner failed")
 		}
 	}()
@@ -106,7 +106,7 @@ func DiskBalance(client *Client, replicaServer string, minSize int64, auto bool)
 					continue
 				}
 
-				if strings.Contains(err.Error(), "ERR_BUSY") {
+				if strings.Contains(err.Error(), base.ERR_BUSY.String()) {
 					fmt.Printf("migrate(%s) is running, msg=%s, wait complete...\n", action.toString(), err.Error())
 					time.Sleep(time.Second * 10)
 					continue

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -270,8 +270,8 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 		return nil, err
 	}
 
-	if highUsageDisk.Ratio < 50 {
-		return nil, fmt.Errorf("no need balance for the high disk still enough capacity(balance threshold=50%%): "+
+	if highUsageDisk.Ratio < 10 {
+		return nil, fmt.Errorf("no need balance for the high disk still enough capacity(balance threshold=10%%): "+
 			"high(%s): %dMB(%d%%); low(%s): %dMB(%d%%)", highUsageDisk.Disk, highUsageDisk.Usage,
 			highUsageDisk.Ratio, lowUsageDisk.Disk, lowUsageDisk.Usage, lowUsageDisk.Ratio)
 	}

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -278,7 +278,7 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 
 	averageUsage := totalUsage / int64(len(disks))
 	averageRatio := totalUsage * 100 / totalCapacity
-	if highUsageDisk.Ratio-lowUsageDisk.Ratio < 10 {
+	if highUsageDisk.Ratio-lowUsageDisk.Ratio < 5 {
 		return nil, fmt.Errorf("no need balance for the disk is balanced:"+
 			" high(%s): %dMB(%d%%); low(%s): %dMB(%d%%); average: %dMB(%d%%)",
 			highUsageDisk.Disk, highUsageDisk.Usage, highUsageDisk.Ratio, lowUsageDisk.Disk,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -338,7 +338,8 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
 	if selectReplica.Size < (10 << 10) {
-		return nil, fmt.Errorf("not suggest balance(%s[%dMB(%d%%)]=>%s[%dMB(%d%%)]): the replica(%s) size is too small, replica size=%dMB, sizeNeedMove=%dMB",
+		return nil, fmt.Errorf("not suggest balance(%s[%dMB(%d%%)]=>%s[%dMB(%d%%)]): "+
+			"the replica(%s) size is too small, replica size=%dMB, sizeNeedMove=%dMB",
 			migrate.HighDisk.DiskCapacity.Disk,
 			migrate.HighDisk.DiskCapacity.Usage,
 			migrate.HighDisk.DiskCapacity.Ratio,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -110,7 +110,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 }
 
 type DiskStats struct {
-	NodeCapacity    NodeCapacityStruct
+	NodeCapacity    DiskCapacityStruct
 	ReplicaCapacity []ReplicaCapacityStruct
 }
 
@@ -213,22 +213,22 @@ func getReplicaSecondaryNode(client *Client, gpid string) (*util.PegasusNode, er
 	return secondaryNode, nil
 }
 
-func queryDiskCapacityInfo(client *Client, replicaServer string) ([]NodeCapacityStruct, int64, int64, error) {
+func queryDiskCapacityInfo(client *Client, replicaServer string) ([]DiskCapacityStruct, int64, int64, error) {
 	diskCapacityOnNode, err := queryDiskInfo(client, CapacitySize, replicaServer, "", "", false)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	util.SortStructsByField(diskCapacityOnNode, "Usage")
-	var disks []NodeCapacityStruct
+	var disks []DiskCapacityStruct
 	var totalUsage int64
 	var totalCapacity int64
 	for _, disk := range diskCapacityOnNode {
-		if s, ok := disk.(NodeCapacityStruct); ok {
+		if s, ok := disk.(DiskCapacityStruct); ok {
 			disks = append(disks, s)
 			totalUsage += s.Usage
 			totalCapacity += s.Capacity
 		} else {
-			return nil, 0, 0, fmt.Errorf("can't covert to NodeCapacityStruct")
+			return nil, 0, 0, fmt.Errorf("can't covert to DiskCapacityStruct")
 		}
 	}
 
@@ -242,7 +242,7 @@ func queryDiskCapacityInfo(client *Client, replicaServer string) ([]NodeCapacity
 	return disks, totalUsage, totalCapacity, nil
 }
 
-func getMigrateDiskInfo(client *Client, replicaServer string, disks []NodeCapacityStruct,
+func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapacityStruct,
 	totalUsage int64, totalCapacity int64) (*MigrateDisk, error) {
 	highUsageDisk := disks[len(disks)-1]
 	highDiskInfo, err := queryDiskInfo(client, CapacitySize, replicaServer, "", highUsageDisk.Disk, false)

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -62,11 +62,11 @@ func DiskMigrate(client *Client, replicaServer string, pidStr string, from strin
 }
 
 func DiskBalance(client *Client, replicaServer string) error {
-	_, err := getNextMigrateAction(client, replicaServer)
+	action, err := getNextMigrateAction(client, replicaServer)
 	if err != nil {
 		return err
 	}
-	return nil
+	return DiskMigrate(client, replicaServer, action.gpid, action.from, action.to)
 }
 
 type DiskStats struct {

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -133,6 +133,10 @@ func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterv
 	if err != nil {
 		return err
 	}
+	err = ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -65,7 +65,7 @@ func DiskMigrate(client *Client, replicaServer string, pidStr string, from strin
 }
 
 func DiskBalance(client *Client, replicaServer string, auto bool) error {
-	err := changeDiskCleanerInterval(client, replicaServer, 10, 1)
+	err := changeDiskCleanerInterval(client, replicaServer, 1)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 		}
 		break
 	}
-	err = changeDiskCleanerInterval(client, replicaServer, 600, 86400)
+	err = changeDiskCleanerInterval(client, replicaServer, 86400)
 	if err != nil {
 		return err
 	}
@@ -122,8 +122,7 @@ type MigrateAction struct {
 	to      string
 }
 
-func changeDiskCleanerInterval(client *Client, replicaServer string, updateInterval int64, cleanInterval int64) error {
-	// todo(disk stat update interval need support in ConfigCommand)
+func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterval int64) error {
 	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_tmp_replica_interval_seconds", "set", cleanInterval)
 	if err != nil {
 		return err

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -255,10 +255,10 @@ func queryDiskCapacityInfo(client *Client, replicaServer string) ([]DiskCapacity
 	}
 
 	if disks == nil {
-		return nil, 0, 0, fmt.Errorf("the node has no ssd")
+		return nil, 0, 0, fmt.Errorf("the node(%s) has no ssd", replicaServer)
 	}
 	if len(disks) == 1 {
-		return nil, 0, 0, fmt.Errorf("only has one disk, can't balance")
+		return nil, 0, 0, fmt.Errorf("the node(%s) only has one disk, can't balance", replicaServer)
 	}
 
 	return disks, totalUsage, totalCapacity, nil
@@ -292,11 +292,11 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 			lowUsageDisk.Usage, lowUsageDisk.Ratio, averageUsage, averageRatio)
 	}
 
-	replicaCapacityOnHighDisk, err := convertReplicaCapacityStruct(highDiskInfo)
+	replicaCapacityOnHighDisk, err := convertReplicaCapacityStruct(highUsageDisk.Disk, highDiskInfo)
 	if err != nil {
 		return nil, err
 	}
-	replicaCapacityOnLowDisk, err := convertReplicaCapacityStruct(lowDiskInfo)
+	replicaCapacityOnLowDisk, err := convertReplicaCapacityStruct(lowUsageDisk.Disk, lowDiskInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +354,7 @@ func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, 
 	}, nil
 }
 
-func convertReplicaCapacityStruct(replicaCapacityInfos []interface{}) ([]ReplicaCapacityStruct, error) {
+func convertReplicaCapacityStruct(disk string, replicaCapacityInfos []interface{}) ([]ReplicaCapacityStruct, error) {
 	util.SortStructsByField(replicaCapacityInfos, "Size")
 	var replicas []ReplicaCapacityStruct
 	for _, replica := range replicaCapacityInfos {
@@ -365,7 +365,7 @@ func convertReplicaCapacityStruct(replicaCapacityInfos []interface{}) ([]Replica
 		}
 	}
 	if replicas == nil {
-		return nil, fmt.Errorf("the ssd has no replica")
+		return nil, fmt.Errorf("the disk(%s) has no replica", disk)
 	}
 	return replicas, nil
 }

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -91,7 +91,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 		}
 		err = DiskMigrate(client, replicaServer, action.replica.Gpid, action.from, action.to)
 		if err == nil {
-			fmt.Printf("migrate(%s from %s to %s) has started, wait complete...\n",
+			fmt.Printf("migrate(%s: %s => %s) has started, wait complete...\n",
 				action.replica.Gpid, action.from, action.to)
 			for {
 				// TODO(jiashuo1): using DiskMigrate RPC to query status, consider support queryDiskMigrateStatus RPC
@@ -102,12 +102,12 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 				}
 
 				if strings.Contains(err.Error(), "ERR_BUSY") {
-					fmt.Printf("migrate(%s from %s to %s) is running, msg=%s, wait complete...\n",
+					fmt.Printf("migrate(%s: %s => %s) is running, msg=%s, wait complete...\n",
 						action.replica.Gpid, action.from, action.to, err.Error())
 					time.Sleep(time.Second * 10)
 					continue
 				}
-				fmt.Printf("migrate(%s from %s to %s) is completed， result=%s",
+				fmt.Printf("migrate(%s: %s => %s) is completed， result=%s",
 					action.replica.Gpid, action.from, action.to, err.Error())
 				break
 			}
@@ -271,7 +271,7 @@ func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapaci
 	}
 
 	if highUsageDisk.Ratio < 10 {
-		return nil, fmt.Errorf("no need balance for the high disk still enough capacity(balance threshold=10%%): "+
+		return nil, fmt.Errorf("no need balance since the high disk still enough capacity(balance threshold=10%%): "+
 			"high(%s): %dMB(%d%%); low(%s): %dMB(%d%%)", highUsageDisk.Disk, highUsageDisk.Usage,
 			highUsageDisk.Ratio, lowUsageDisk.Disk, lowUsageDisk.Usage, lowUsageDisk.Ratio)
 	}
@@ -323,8 +323,8 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 	}
 
 	if selectReplica == nil {
-		return nil, fmt.Errorf("can't balance: sizeNeedMove=%dMB, but the min replica(%s) size is %dMB",
-			sizeNeedMove, migrate.HighDisk.ReplicaCapacity[0].Gpid, migrate.HighDisk.ReplicaCapacity[0].Size)
+		return nil, fmt.Errorf("can't balance(%s => %s): sizeNeedMove=%dMB, but the min replica(%s) size is %dMB on high disk",
+			migrate.HighDisk.NodeCapacity.Disk, migrate.LowDisk.NodeCapacity.Disk, sizeNeedMove, migrate.HighDisk.ReplicaCapacity[0].Gpid, migrate.HighDisk.ReplicaCapacity[0].Size)
 	}
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -107,7 +107,7 @@ func DiskBalance(client *Client, replicaServer string, auto bool) error {
 					time.Sleep(time.Second * 10)
 					continue
 				}
-				fmt.Printf("migrate(%s: %s => %s) is completed， result=%s\n",
+				fmt.Printf("migrate(%s: %s => %s) is completed，result=%s\n\n",
 					action.replica.Gpid, action.from, action.to, err.Error())
 				break
 			}
@@ -333,7 +333,7 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 			migrate.HighDisk.DiskCapacity.Disk, migrate.LowDisk.DiskCapacity.Disk, selectReplica.Gpid, selectReplica.Size, sizeNeedMove)
 	}
 
-	fmt.Printf("ACTION:disk migrate(sizeNeedMove=%dMB): node=%s, %s(%dMB[%d%%])=>%s(%dMB[%d%%]), gpid(%s)=%s(%dMB)\n",
+	fmt.Printf("ACTION:disk migrate(sizeNeedMove=%dMB): node=%s, %s[%dMB(%d%%)]=>%s[%dMB(%d%%)], gpid(%s)=%s(%dMB)\n",
 		sizeNeedMove, migrate.currentNode,
 		migrate.HighDisk.DiskCapacity.Disk,
 		migrate.HighDisk.DiskCapacity.Usage,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -157,11 +157,11 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 
 	lowDiskCanReceiveMax := migrateDisk.AverageUsage - migrateDisk.LowDisk.NodeCapacity.Usage
 	highDiskCanSendMax := migrateDisk.HighDisk.NodeCapacity.Usage - averageUsage
-	SizeToMove := math.Min(float64(lowDiskCanReceiveMax), float64(highDiskCanSendMax))
+	SizeToMove := int64(math.Min(float64(lowDiskCanReceiveMax), float64(highDiskCanSendMax)))
 
 	var selectReplica ReplicaCapacityStruct
 	for i := len(migrateDisk.HighDisk.ReplicaCapacity) - 1; i > 0; i++ {
-		if migrateDisk.HighDisk.ReplicaCapacity[i].Size > SizeToMove {
+		if int64(migrateDisk.HighDisk.ReplicaCapacity[i].Size) > SizeToMove {
 			continue
 		} else {
 			selectReplica = migrateDisk.HighDisk.ReplicaCapacity[i]
@@ -169,7 +169,7 @@ func getNextMigrateAction(client *Client, replicaServer string) (*MigrateAction,
 		}
 	}
 
-	fmt.Printf("disk migrate(sizeToMove=%fMB): node=%s, from=%s, to=%s, gpid(best)=%s(size=%f)\n",
+	fmt.Printf("disk migrate(sizeToMove=%dMB): node=%s, from=%s, to=%s, gpid(best)=%s(size=%dMB)\n",
 		SizeToMove, replicaServer,
 		migrateDisk.HighDisk.NodeCapacity.Disk,
 		migrateDisk.LowDisk.NodeCapacity.Disk,

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -22,14 +22,11 @@ package executor
 import (
 	"context"
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
-	"github.com/XiaoMi/pegasus-go-client/idl/admin"
 	"github.com/XiaoMi/pegasus-go-client/idl/radmin"
 	"github.com/XiaoMi/pegasus-go-client/session"
-	adminClient "github.com/pegasus-kv/admin-cli/client"
 	"github.com/pegasus-kv/admin-cli/util"
 )
 
@@ -64,6 +61,15 @@ func DiskMigrate(client *Client, replicaServer string, pidStr string, from strin
 	return nil
 }
 
+// auto balance target node disk usage:
+// -1. change the pegasus server disk cleaner internal for clean temp replica to free disk space in time
+// -2. get the optimal migrate action to be ready to balance the disk until can't migrate base latest disk space stats
+// -3. if current replica is `Secondary` status, force assign the replica to Secondary status
+// -4. migrate the replica base `getNextMigrateAction` result
+// -5. loop query migrate progress using `DiskMigrate`, it will response `ERR_BUSY` if running
+// -6. start next loop until can't allow to balance the node
+// -7. recover disk cleaner internal if balance complete
+// -8. set meta status to `lively` to balance primary and secondary // TODO(jiashuo1)
 func DiskBalance(client *Client, replicaServer string, minSize int64, auto bool) error {
 	err := changeDiskCleanerInterval(client, replicaServer, 1)
 	if err != nil {
@@ -117,6 +123,7 @@ func DiskBalance(client *Client, replicaServer string, minSize int64, auto bool)
 		}
 		break
 	}
+
 	return nil
 }
 
@@ -127,15 +134,8 @@ type DiskStats struct {
 
 type MigrateDisk struct {
 	AverageUsage int64
-	currentNode  string
 	HighDisk     DiskStats
 	LowDisk      DiskStats
-}
-
-func (m *MigrateDisk) toString() string {
-	return fmt.Sprintf("Node=%s, HighDisk=%s[%dMB(%d%%)]=>LowDisk=%s[%dMB(%d%%)]", m.currentNode,
-		m.HighDisk.DiskCapacity.Disk, m.HighDisk.DiskCapacity.Usage, m.HighDisk.DiskCapacity.Ratio,
-		m.LowDisk.DiskCapacity.Disk, m.LowDisk.DiskCapacity.Usage, m.LowDisk.DiskCapacity.Ratio)
 }
 
 type MigrateAction struct {
@@ -149,223 +149,17 @@ func (m *MigrateAction) toString() string {
 	return fmt.Sprintf("node=%s, replica=%s, %s=>%s", m.node, m.replica.Gpid, m.from, m.to)
 }
 
+// TODO(jiashuo1): next pr
 func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterval int64) error {
-	fmt.Printf("set gc_disk_migration_origin_replica_interval_seconds = %ds ", cleanInterval)
-	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
+// TODO(jiashuo1):next pr
 func getNextMigrateAction(client *Client, replicaServer string, minSize int64) (*MigrateAction, error) {
-	disks, totalUsage, totalCapacity, err := queryDiskCapacityInfo(client, replicaServer)
-	if err != nil {
-		return nil, err
-	}
-	diskMigrateInfo, err := getMigrateDiskInfo(client, replicaServer, disks, totalUsage, totalCapacity)
-	if err != nil {
-		return nil, err
-	}
-
-	migrateAction, err := computeMigrateAction(diskMigrateInfo, minSize)
-	if err != nil {
-		return nil, err
-	}
-	return migrateAction, nil
+	return nil, nil
 }
 
+// TODO(jiashuo1):next pr
 func forceAssignReplicaToSecondary(client *Client, replicaServer string, gpid string) error {
-	fmt.Printf("WARNING: the select replica is not secondary, will force assign it secondary\n")
-	_, err := client.Meta.MetaControl(admin.MetaFunctionLevel_fl_steady)
-	if err != nil {
-		return err
-	}
-	secondaryNode, err := getReplicaSecondaryNode(client, gpid)
-	if err != nil {
-		return err
-	}
-	replica, err := util.Str2Gpid(gpid)
-	if err != nil {
-		return err
-	}
-	err = client.Meta.Balance(replica, adminClient.BalanceMovePri,
-		util.NewNodeFromTCPAddr(replicaServer, session.NodeTypeReplica), secondaryNode)
-	if err != nil {
-		return err
-	}
 	return nil
-}
-
-func getReplicaSecondaryNode(client *Client, gpid string) (*util.PegasusNode, error) {
-	replica, err := util.Str2Gpid(gpid)
-	if err != nil {
-		return nil, err
-	}
-	tables, err := client.Meta.ListApps(admin.AppStatus_AS_AVAILABLE)
-	if err != nil {
-		return nil, fmt.Errorf("can't get the table name of replica %s when migrate the replica", gpid)
-	}
-	var tableName string
-	for _, tb := range tables {
-		if tb.AppID == replica.Appid {
-			tableName = tb.AppName
-			break
-		}
-	}
-	if tableName == "" {
-		return nil, fmt.Errorf("can't find the table for %s when migrate the replica", gpid)
-	}
-
-	resp, err := client.Meta.QueryConfig(tableName)
-	if err != nil {
-		return nil, fmt.Errorf("can't get the table %s configuration when migrate the replica(%s): %s", tableName, gpid, err)
-	}
-
-	var secondaryNode *util.PegasusNode
-	for _, partition := range resp.Partitions {
-		if partition.Pid.String() == replica.String() {
-			secondaryNode = util.NewNodeFromTCPAddr(partition.Secondaries[0].GetAddress(), session.NodeTypeReplica)
-		}
-	}
-
-	if secondaryNode == nil {
-		return nil, fmt.Errorf("can't get the replica %s secondary node", gpid)
-	}
-	return secondaryNode, nil
-}
-
-func queryDiskCapacityInfo(client *Client, replicaServer string) ([]DiskCapacityStruct, int64, int64, error) {
-	diskCapacityOnNode, err := queryDiskInfo(client, CapacitySize, replicaServer, "", "", false)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-	util.SortStructsByField(diskCapacityOnNode, "Usage")
-	var disks []DiskCapacityStruct
-	var totalUsage int64
-	var totalCapacity int64
-	for _, disk := range diskCapacityOnNode {
-		if s, ok := disk.(DiskCapacityStruct); ok {
-			disks = append(disks, s)
-			totalUsage += s.Usage
-			totalCapacity += s.Capacity
-		} else {
-			return nil, 0, 0, fmt.Errorf("can't covert to DiskCapacityStruct")
-		}
-	}
-
-	if disks == nil {
-		return nil, 0, 0, fmt.Errorf("the node(%s) has no ssd", replicaServer)
-	}
-	if len(disks) == 1 {
-		return nil, 0, 0, fmt.Errorf("the node(%s) only has one disk, can't balance", replicaServer)
-	}
-
-	return disks, totalUsage, totalCapacity, nil
-}
-
-func getMigrateDiskInfo(client *Client, replicaServer string, disks []DiskCapacityStruct,
-	totalUsage int64, totalCapacity int64) (*MigrateDisk, error) {
-	highUsageDisk := disks[len(disks)-1]
-	highDiskInfo, err := queryDiskInfo(client, CapacitySize, replicaServer, "", highUsageDisk.Disk, false)
-	if err != nil {
-		return nil, err
-	}
-	lowUsageDisk := disks[0]
-	lowDiskInfo, err := queryDiskInfo(client, CapacitySize, replicaServer, "", lowUsageDisk.Disk, false)
-	if err != nil {
-		return nil, err
-	}
-
-	if highUsageDisk.Ratio < 10 {
-		return nil, fmt.Errorf("no need balance since the high disk still enough capacity(balance threshold=10%%): "+
-			"high(%s): %dMB(%d%%); low(%s): %dMB(%d%%)", highUsageDisk.Disk, highUsageDisk.Usage,
-			highUsageDisk.Ratio, lowUsageDisk.Disk, lowUsageDisk.Usage, lowUsageDisk.Ratio)
-	}
-
-	averageUsage := totalUsage / int64(len(disks))
-	averageRatio := totalUsage * 100 / totalCapacity
-	if highUsageDisk.Ratio-lowUsageDisk.Ratio < 5 {
-		return nil, fmt.Errorf("no need balance since the disk is balanced:"+
-			" high(%s): %dMB(%d%%); low(%s): %dMB(%d%%); average: %dMB(%d%%)",
-			highUsageDisk.Disk, highUsageDisk.Usage, highUsageDisk.Ratio, lowUsageDisk.Disk,
-			lowUsageDisk.Usage, lowUsageDisk.Ratio, averageUsage, averageRatio)
-	}
-
-	replicaCapacityOnHighDisk, err := convertReplicaCapacityStruct(highDiskInfo)
-	if err != nil { // we need migrate replica from high disk, so the convert must be successful
-		return nil, fmt.Errorf("parse replica info on high disk(%s) failed: %s", highUsageDisk.Disk, err.Error())
-	}
-	replicaCapacityOnLowDisk, err := convertReplicaCapacityStruct(lowDiskInfo)
-	if err != nil { // we don't care the replica capacity info on low disk, if convert failed, we only log warning and know the result=nil
-		fmt.Printf("WARNING: parse replica info on low disk(%s) failed: %s", lowUsageDisk.Disk, err.Error())
-	}
-	return &MigrateDisk{
-		AverageUsage: averageUsage,
-		currentNode:  replicaServer,
-		HighDisk: DiskStats{
-			DiskCapacity:    highUsageDisk,
-			ReplicaCapacity: replicaCapacityOnHighDisk,
-		},
-		LowDisk: DiskStats{
-			DiskCapacity:    lowUsageDisk,
-			ReplicaCapacity: replicaCapacityOnLowDisk,
-		},
-	}, nil
-}
-
-func computeMigrateAction(migrate *MigrateDisk, minSize int64) (*MigrateAction, error) {
-	lowDiskCanReceiveMax := migrate.AverageUsage - migrate.LowDisk.DiskCapacity.Usage
-	highDiskCanSendMax := migrate.HighDisk.DiskCapacity.Usage - migrate.AverageUsage
-	sizeNeedMove := int64(math.Min(float64(lowDiskCanReceiveMax), float64(highDiskCanSendMax)))
-
-	var selectReplica *ReplicaCapacityStruct
-	for i := len(migrate.HighDisk.ReplicaCapacity) - 1; i >= 0; i-- {
-		if migrate.HighDisk.ReplicaCapacity[i].Size > sizeNeedMove {
-			continue
-		} else {
-			selectReplica = &migrate.HighDisk.ReplicaCapacity[i]
-			break
-		}
-	}
-
-	if selectReplica == nil {
-		return nil, fmt.Errorf("can't balance(%s): high disk min replica(%s) size(%dMB) must <= sizeNeedMove(%dMB)",
-			migrate.toString(),
-			migrate.HighDisk.ReplicaCapacity[0].Gpid,
-			migrate.HighDisk.ReplicaCapacity[0].Size,
-			sizeNeedMove)
-	}
-
-	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
-	if selectReplica.Size < minSize {
-		return nil, fmt.Errorf("not suggest balance(%s): the qualified(must<=sizeNeedMove(%dMB)) replica size(%s=%dMB) must >= minSize(%dMB))",
-			migrate.toString(), sizeNeedMove, selectReplica.Gpid, selectReplica.Size, minSize)
-	}
-
-	fmt.Printf("ACTION:disk migrate(sizeNeedMove=%dMB): %s, gpid(%s)=%s(%dMB)\n",
-		sizeNeedMove, migrate.toString(), selectReplica.Status, selectReplica.Gpid, selectReplica.Size)
-
-	return &MigrateAction{
-		node:    migrate.currentNode,
-		replica: *selectReplica,
-		from:    migrate.HighDisk.DiskCapacity.Disk,
-		to:      migrate.LowDisk.DiskCapacity.Disk,
-	}, nil
-}
-
-func convertReplicaCapacityStruct(replicaCapacityInfos []interface{}) ([]ReplicaCapacityStruct, error) {
-	util.SortStructsByField(replicaCapacityInfos, "Size")
-	var replicas []ReplicaCapacityStruct
-	for _, replica := range replicaCapacityInfos {
-		if r, ok := replica.(ReplicaCapacityStruct); ok {
-			replicas = append(replicas, r)
-		} else {
-			return nil, fmt.Errorf("can't covert to ReplicaCapacityStruct")
-		}
-	}
-	if replicas == nil {
-		return nil, fmt.Errorf("the disk has no replica")
-	}
-	return replicas, nil
 }

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -68,7 +68,7 @@ func DiskBalance(client *Client, replicaServer string) error {
 		return err
 	}
 
-	fmt.Printf("disk migrate: %v", migrateAction)
+	fmt.Printf("disk migrate: %v\n", migrateAction)
 	return nil
 }
 

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -143,7 +143,7 @@ type MigrateAction struct {
 }
 
 func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterval int64) error {
-	fmt.Printf("set gc_disk_migration_origin_replica_interval_seconds = %ds",  cleanInterval)
+	fmt.Printf("set gc_disk_migration_origin_replica_interval_seconds = %ds ",  cleanInterval)
 	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
 	if err != nil {
 		return err

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -64,7 +64,7 @@ func DiskMigrate(client *Client, replicaServer string, pidStr string, from strin
 // auto balance target node disk usage:
 // -1. change the pegasus server disk cleaner internal for clean temp replica to free disk space in time
 // -2. get the optimal migrate action to be ready to balance the disk until can't migrate base latest disk space stats
-// -3. if current replica is `Secondary` status, force assign the replica to Secondary status
+// -3. if current replica is `primary` status, force assign the replica to `secondary` status
 // -4. migrate the replica base `getNextMigrateAction` result
 // -5. loop query migrate progress using `DiskMigrate`, it will response `ERR_BUSY` if running
 // -6. start next loop until can't allow to balance the node

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -143,6 +143,7 @@ type MigrateAction struct {
 }
 
 func changeDiskCleanerInterval(client *Client, replicaServer string, cleanInterval int64) error {
+	fmt.Printf("set gc_disk_migration_origin_replica_interval_seconds = %ds",  cleanInterval)
 	err := ConfigCommand(client, session.NodeTypeReplica, replicaServer, "gc_disk_migration_origin_replica_interval_seconds", "set", cleanInterval)
 	if err != nil {
 		return err

--- a/executor/disk_balance.go
+++ b/executor/disk_balance.go
@@ -338,8 +338,16 @@ func computeMigrateAction(migrate *MigrateDisk) (*MigrateAction, error) {
 
 	// if select replica size is too small, it will need migrate many replica and result in `replica count not balance` among disk
 	if selectReplica.Size < (10 << 10) {
-		return nil, fmt.Errorf("not suggest balance(%s => %s): the replica(%s) size is too small, replica size=%dMB, sizeNeedMove=%dMB",
-			migrate.HighDisk.DiskCapacity.Disk, migrate.LowDisk.DiskCapacity.Disk, selectReplica.Gpid, selectReplica.Size, sizeNeedMove)
+		return nil, fmt.Errorf("not suggest balance(%s[%dMB(%d%%)]=>%s[%dMB(%d%%)]): the replica(%s) size is too small, replica size=%dMB, sizeNeedMove=%dMB",
+			migrate.HighDisk.DiskCapacity.Disk,
+			migrate.HighDisk.DiskCapacity.Usage,
+			migrate.HighDisk.DiskCapacity.Ratio,
+			migrate.LowDisk.DiskCapacity.Disk,
+			migrate.LowDisk.DiskCapacity.Usage,
+			migrate.LowDisk.DiskCapacity.Ratio,
+			selectReplica.Gpid,
+			selectReplica.Size,
+			sizeNeedMove)
 	}
 
 	fmt.Printf("ACTION:disk migrate(sizeNeedMove=%dMB): node=%s, %s[%dMB(%d%%)]=>%s[%dMB(%d%%)], gpid(%s)=%s(%dMB)\n",

--- a/executor/disk_info.go
+++ b/executor/disk_info.go
@@ -39,7 +39,6 @@ const (
 )
 
 // QueryDiskInfo command
-// TODO(jiashuo1) need refactor
 func QueryDiskInfo(client *Client, infoType DiskInfoType, replicaServer string, tableName string, diskTag string) ([]interface{}, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()

--- a/executor/disk_info.go
+++ b/executor/disk_info.go
@@ -75,7 +75,7 @@ func queryDiskInfo(client *Client, infoType DiskInfoType, replicaServer string, 
 	}
 }
 
-type NodeCapacityStruct struct {
+type DiskCapacityStruct struct {
 	Disk     string `json:"disk"`
 	Capacity int64  `json:"capacity"`
 	Usage    int64  `json:"usage"`
@@ -89,7 +89,7 @@ type ReplicaCapacityStruct struct {
 }
 
 func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryDiskInfoResponse, diskTag string, print bool) []interface{} {
-	var nodeCapacityInfos []interface{}
+	var diskCapacityInfos []interface{}
 	var replicaCapacityInfos []interface{}
 
 	perfSession := client.Nodes.GetPerfSession(replicaServer, session.NodeTypeReplica)
@@ -119,7 +119,7 @@ func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryD
 			return replicaCapacityInfos
 		}
 
-		nodeCapacityInfos = append(nodeCapacityInfos, NodeCapacityStruct{
+		diskCapacityInfos = append(diskCapacityInfos, DiskCapacityStruct{
 			Disk:     diskInfo.Tag,
 			Capacity: diskInfo.DiskCapacityMb,
 			Usage:    diskInfo.DiskCapacityMb - diskInfo.DiskAvailableMb,
@@ -128,9 +128,9 @@ func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryD
 	}
 
 	if print {
-		tabular.Print(client.Writer, nodeCapacityInfos)
+		tabular.Print(client.Writer, diskCapacityInfos)
 	}
-	return nodeCapacityInfos
+	return diskCapacityInfos
 }
 
 func queryDiskReplicaCount(client *Client, resp *radmin.QueryDiskInfoResponse, print bool) []interface{} {

--- a/executor/disk_info.go
+++ b/executor/disk_info.go
@@ -41,10 +41,7 @@ const (
 // QueryDiskInfo command
 func QueryDiskInfo(client *Client, infoType DiskInfoType, replicaServer string, tableName string, diskTag string) error {
 	_, err := queryDiskInfo(client, infoType, replicaServer, tableName, diskTag, true)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func queryDiskInfo(client *Client, infoType DiskInfoType, replicaServer string, tableName string, diskTag string, print bool) ([]interface{}, error) {

--- a/executor/disk_info.go
+++ b/executor/disk_info.go
@@ -83,9 +83,9 @@ type NodeCapacityStruct struct {
 }
 
 type ReplicaCapacityStruct struct {
-	Replica string `json:"replica"`
-	Status  string `json:"status"`
-	Size    int64  `json:"size"`
+	Gpid   string `json:"replica"`
+	Status string `json:"status"`
+	Size   int64  `json:"size"`
 }
 
 func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryDiskInfoResponse, diskTag string, print bool) []interface{} {
@@ -102,9 +102,9 @@ func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryD
 					for _, replica := range replicas {
 						var gpidStr = fmt.Sprintf("%d.%d", replica.Appid, replica.PartitionIndex)
 						replicaCapacityInfos = append(replicaCapacityInfos, ReplicaCapacityStruct{
-							Replica: gpidStr,
-							Status:  replicaStatus,
-							Size:    int64(partitionStats[gpidStr]),
+							Gpid:   gpidStr,
+							Status: replicaStatus,
+							Size:   int64(partitionStats[gpidStr]),
 						})
 					}
 				}

--- a/executor/disk_info.go
+++ b/executor/disk_info.go
@@ -76,9 +76,9 @@ type NodeCapacityStruct struct {
 }
 
 type ReplicaCapacityStruct struct {
-	Replica string  `json:"replica"`
-	Status  string  `json:"status"`
-	Size    float64 `json:"size"`
+	Replica string `json:"replica"`
+	Status  string `json:"status"`
+	Size    int64  `json:"size"`
 }
 
 func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryDiskInfoResponse, diskTag string) []interface{} {
@@ -97,7 +97,7 @@ func queryDiskCapacity(client *Client, replicaServer string, resp *radmin.QueryD
 						replicaCapacityInfos = append(replicaCapacityInfos, ReplicaCapacityStruct{
 							Replica: gpidStr,
 							Status:  replicaStatus,
-							Size:    partitionStats[gpidStr],
+							Size:    int64(partitionStats[gpidStr]),
 						})
 					}
 				}

--- a/executor/list_nodes.go
+++ b/executor/list_nodes.go
@@ -34,7 +34,7 @@ import (
 type nodeInfoStruct struct {
 	Address           string `json:"Node"`
 	Status            string `json:"Status"`
-	ReplicaTotalCount int    `json:"Gpid"`
+	ReplicaTotalCount int    `json:"Replica"`
 	PrimaryCount      int    `json:"Primary"`
 	SecondaryCount    int    `json:"Secondary"`
 }

--- a/executor/list_nodes.go
+++ b/executor/list_nodes.go
@@ -34,7 +34,7 @@ import (
 type nodeInfoStruct struct {
 	Address           string `json:"Node"`
 	Status            string `json:"Status"`
-	ReplicaTotalCount int    `json:"Replica"`
+	ReplicaTotalCount int    `json:"Gpid"`
 	PrimaryCount      int    `json:"Primary"`
 	SecondaryCount    int    `json:"Secondary"`
 }

--- a/util/common_utils.go
+++ b/util/common_utils.go
@@ -56,10 +56,10 @@ func SortStructsByField(structs []interface{}, key string) {
 		v2 := reflect.ValueOf(structs[j]).FieldByName(key)
 		if v1.Type().Name() == "string" {
 			return strings.Compare(v1.String(), v2.String()) < 0
-		} else if v1.Type().Name() == "int" ||
-			v1.Type().Name() == "int64" ||
-			v1.Type().Name() == "float64" {
+		} else if v1.Type().Name() == "int" || v1.Type().Name() == "int64" {
 			return v1.Int() < v2.Int()
+		} else if v1.Type().Name() == "float64" {
+			return v1.Float() < v2.Float()
 		} else {
 			panic(fmt.Sprintf("Not support sort %s", v1.Type().Name()))
 		}


### PR DESCRIPTION
- **init framework for adding disk balance automatically**  https://github.com/pegasus-kv/admin-cli/pull/37
- implement framework for adding disk balance automatically https://github.com/pegasus-kv/admin-cli/pull/38
- complete framework for adding disk balance automatically https://github.com/pegasus-kv/admin-cli/pull/39

support balance target node disk usage automatically:
 1. change the pegasus server disk cleaner internal for clean temp replica to free disk space in time
 2. get the optimal migrate action to be ready to balance the disk until can't migrate base latest disk space stats
 3. if current replica is not `secondary` status, force assign the replica to `secondary` status
 4. migrate the replica base `getNextMigrateAction` result
 5. loop query migrate progress using `DiskMigrate`, it will response `ERR_BUSY` if running
 6. start next loop until can't allow to balance the node
 7. recover disk cleaner internal if balance complete
 8. set meta status to `lively` to balance primary and secondary