### PR TITLE
feat: support partition split related commands

### DIFF
--- a/client/fake_meta_test.go
+++ b/client/fake_meta_test.go
@@ -205,3 +205,23 @@ func (m *fakeMeta) RestoreApp(oldClusterName string, oldTableName string, oldTab
 	newTableName string, restorePath string, skipBadPartition bool, policyName string) (*admin.CreateAppResponse, error) {
 	panic("unimplemented")
 }
+
+func (m *fakeMeta) StartPartitionSplit(tableName string, newPartitionCount int) error {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) QuerySplitStatus(tableName string) (*admin.QuerySplitResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) PausePartitionSplit(tableName string, parentPidx int) error {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) RestartPartitionSplit(tableName string, parentPidx int) error {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) CancelPartitionSplit(tableName string, oldPartitionCount int) error {
+	panic("unimplemented")
+}

--- a/cmd/partition_split.go
+++ b/cmd/partition_split.go
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/desertbit/grumble"
+	"github.com/pegasus-kv/admin-cli/executor"
+	"github.com/pegasus-kv/admin-cli/shell"
+)
+
+func init() {
+
+	shell.AddCommand(&grumble.Command{
+		Name: "start-partition-split",
+		Help: "start partition split for a specific table",
+		Usage: `start-partition-split 
+		<-a|--tableName TABLE_NAME> 
+		<-p|--newPartitionCount NEW_PARTITION_COUNT>`,
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			if c.Flags.Int("newPartitionCount") == 0 {
+				return fmt.Errorf("newPartitionCount cannot be empty")
+			}
+
+			tableName := c.Flags.String("tableName")
+			newPartitionCount := c.Flags.Int("newPartitionCount")
+			return executor.StartPartitionSplit(pegasusClient, tableName, newPartitionCount)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.Int("p", "newPartitionCount", 0, "new_partition_count, should be double of current partition_count")
+		},
+	})
+
+	shell.AddCommand(&grumble.Command{
+		Name:  "query-split-status",
+		Help:  "query partition split status for a specific table",
+		Usage: "query-split-status <-a|--tableName TABLE_NAME>",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			return executor.QuerySplitStatus(pegasusClient, tableName)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+		},
+	})
+
+	shell.AddCommand(&grumble.Command{
+		Name:  "pause-partition-split",
+		Help:  "pause partition split for specific partition or all partitions of a table",
+		Usage: "pause-partition-split <-a|--tableName TABLE_NAME> [-i|--parentPidx PARENT_PIDX]",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			parentPidx := c.Flags.Int("parentPidx")
+			return executor.PausePartitionSplit(pegasusClient, tableName, parentPidx)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.Int("i", "parentPidx", -1, "parent partition index")
+		},
+	})
+
+	shell.AddCommand(&grumble.Command{
+		Name:  "restart-partition-split",
+		Help:  "restart partition split for specific partition or all partitions of a table",
+		Usage: "restart-partition-split <-a|--tableName TABLE_NAME> [-i|--parentPidx PARENT_PIDX]",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			parentPidx := c.Flags.Int("parentPidx")
+			return executor.RestartPartitionSplit(pegasusClient, tableName, parentPidx)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.Int("i", "parentPidx", -1, "parent partition index")
+		},
+	})
+
+	shell.AddCommand(&grumble.Command{
+		Name:  "cancel-partition-split",
+		Help:  "cancel partition split for a specific table",
+		Usage: "cancel-partition-split <-a|--tableName TABLE_NAME> [-p|--oldPartitionCount OLD_PARTITION_COUNT]",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			if c.Flags.Int("oldPartitionCount") == 0 {
+				return fmt.Errorf("oldPartitionCount cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			oldPartitionCount := c.Flags.Int("oldPartitionCount")
+			return executor.CancelPartitionSplit(pegasusClient, tableName, oldPartitionCount)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.Int("p", "oldPartitionCount", 0, "table partition count before split")
+		},
+	})
+}

--- a/executor/partition_split.go
+++ b/executor/partition_split.go
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"fmt"
+
+	"github.com/pegasus-kv/admin-cli/tabular"
+)
+
+func StartPartitionSplit(client *Client, tableName string, newPartitionCount int) error {
+	err := client.Meta.StartPartitionSplit(tableName, newPartitionCount)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Table %s start partition split succeed\n", tableName)
+	return nil
+}
+
+func QuerySplitStatus(client *Client, tableName string) error {
+	resp, err := client.Meta.QuerySplitStatus(tableName)
+	if err != nil {
+		return err
+	}
+	// show all partitions split status
+	type splitStatusStruct struct {
+		PartitionIndex int32  `json:"Pidx"`
+		Status         string `json:"SplitStatus"`
+	}
+	fmt.Println("[AllPartitionStatus]")
+	var pList []interface{}
+	var i int32 = 0
+	statusMap := resp.GetStatus()
+	for ; i < resp.GetNewPartitionCount_()/2; i++ {
+		var status string
+		value, ok := statusMap[i]
+		if ok {
+			status = value.String()
+		} else {
+			status = "COMPLETED"
+		}
+		pList = append(pList, splitStatusStruct{
+			PartitionIndex: i,
+			Status:         status,
+		})
+	}
+	tabular.Print(client, pList)
+
+	// show summary count
+	fmt.Println("[Summary]")
+	var sList []interface{}
+	type summaryStruct struct {
+		SplittingCount int32 `json:"SplittingCount"`
+		CompletedCount int32 `json:"CompletedCount"`
+	}
+	sList = append(sList, summaryStruct{
+		SplittingCount: int32(len(statusMap)),
+		CompletedCount: resp.GetNewPartitionCount_()/2 - int32(len(statusMap)),
+	})
+	tabular.Print(client, sList)
+	return nil
+}
+
+func PausePartitionSplit(client *Client, tableName string, parentPidx int) error {
+	err := client.Meta.PausePartitionSplit(tableName, parentPidx)
+	if err != nil {
+		return err
+	}
+	if parentPidx < 0 {
+		fmt.Printf("Table %s all partition pause split succeed\n", tableName)
+	} else {
+		fmt.Printf("Table %s partition[%d] pause split succeed\n", tableName, parentPidx)
+	}
+	return nil
+}
+
+func RestartPartitionSplit(client *Client, tableName string, parentPidx int) error {
+	err := client.Meta.RestartPartitionSplit(tableName, parentPidx)
+	if err != nil {
+		return err
+	}
+	if parentPidx < 0 {
+		fmt.Printf("Table %s all partition restart split succeed\n", tableName)
+	} else {
+		fmt.Printf("Table %s partition[%d] restart split succeed\n", tableName, parentPidx)
+	}
+	return nil
+}
+
+func CancelPartitionSplit(client *Client, tableName string, oldPartitionCount int) error {
+	err := client.Meta.CancelPartitionSplit(tableName, oldPartitionCount)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Table %s cancel partition split succeed\n", tableName)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pegasus-kv/admin-cli
 go 1.14
 
 require (
-	github.com/XiaoMi/pegasus-go-client v0.0.0-20210508064509-3af6e8b3c3c4
+	github.com/XiaoMi/pegasus-go-client v0.0.0-20210909025008-2702bf2b9034
 	github.com/cheggaaa/pb/v3 v3.0.6
 	github.com/desertbit/grumble v1.1.1
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/XiaoMi/pegasus-go-client v0.0.0-20201127155445-d3b9a03abf6e/go.mod h1:H83dStz3HvHBFC0n7QK+qLHAjqsIghFOFx2TCvq6vzI=
-github.com/XiaoMi/pegasus-go-client v0.0.0-20210508064509-3af6e8b3c3c4 h1:Wa2/gHZqf+1tcYQWOGpjMEP2iyelc//X9F43bVrS7/w=
-github.com/XiaoMi/pegasus-go-client v0.0.0-20210508064509-3af6e8b3c3c4/go.mod h1:VrfgKISflRhFm32m3e0SXLccvNJTyG8PRywWbUuGEfY=
+github.com/XiaoMi/pegasus-go-client v0.0.0-20210909025008-2702bf2b9034 h1:6IpsU46sD3Ewk2Sq2ORw0IhYI7cDNDQmbGywNsRnUxQ=
+github.com/XiaoMi/pegasus-go-client v0.0.0-20210909025008-2702bf2b9034/go.mod h1:VrfgKISflRhFm32m3e0SXLccvNJTyG8PRywWbUuGEfY=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
 github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=


### PR DESCRIPTION
This pull request support partition split related commands, including: start, query, pause, restart and cancenl. 
The test result by onebox is like below:
### start partition split
```
Pegasus-AdminCli-1.1.0 » start-partition-split -a stat -p 8
Table stat start partition split succeed
```
### query split status
```
Pegasus-AdminCli-1.1.0 » query-split-status -a stat
[AllPartitionStatus]
+------+-------------+
| Pidx | SplitStatus |
+------+-------------+
| 0    | SPLITTING   |
| 1    | SPLITTING   |
| 2    | SPLITTING   |
| 3    | COMPLETED   |
+------+-------------+
[Summary]
+----------------+----------------+
| SplittingCount | CompletedCount |
+----------------+----------------+
| 3              | 1              |
+----------------+----------------+
```
### pause partition split
```
Pegasus-AdminCli-1.1.0 » pause-partition-split -a stat -i 3
Table stat partition[3] pause split succeed
```
### restart partition split
```
Pegasus-AdminCli-1.1.0 » restart-partition-split -a stat 
Table stat all partition restart split succeed
```
### cancel partition split
```
Pegasus-AdminCli-1.1.0 » cancel-partition-split -a stat -p 4
Table stat cancel partition split succeed
```