### PR TITLE
feat: support bulk load rpc

### DIFF
--- a/client/fake_meta_test.go
+++ b/client/fake_meta_test.go
@@ -225,3 +225,23 @@ func (m *fakeMeta) RestartPartitionSplit(tableName string, parentPidx int) error
 func (m *fakeMeta) CancelPartitionSplit(tableName string, oldPartitionCount int) error {
 	panic("unimplemented")
 }
+
+func (m *fakeMeta) StartBulkLoad(tableName string, clusterName string, providerType string, rootPath string) error {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) QueryBulkLoad(tableName string) (*admin.QueryBulkLoadResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) PauseBulkLoad(tableName string) error {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) RestartBulkLoad(tableName string) error {
+	panic("unimplemented")
+}
+
+func (m *fakeMeta) CancelBulkLoad(tableName string, forced bool) error {
+	panic("unimplemented")
+}

--- a/cmd/bulk_load.go
+++ b/cmd/bulk_load.go
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/desertbit/grumble"
+	"github.com/pegasus-kv/admin-cli/executor"
+	"github.com/pegasus-kv/admin-cli/shell"
+)
+
+func init() {
+	rootCmd := &grumble.Command{
+		Name: "bulk-load",
+		Help: "bulk load related commands",
+	}
+
+	rootCmd.AddCommand(&grumble.Command{
+		Name:  "start",
+		Help:  "start bulk load for a specific table",
+		Usage: `start <-a|--tableName TABLE_NAME> <-c|--clusterName CLUSTER_NAME> <-p|--providerType PROVIDER_TYPE> <-r|--rootPath ROOT_PATH>`,
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			if c.Flags.String("clusterName") == "" {
+				return fmt.Errorf("clusterName cannot be empty")
+			}
+			if c.Flags.String("providerType") == "" {
+				return fmt.Errorf("providerType cannot be empty")
+			}
+			if c.Flags.String("rootPath") == "" {
+				return fmt.Errorf("rootPath cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			clusterName := c.Flags.String("clusterName")
+			providerType := c.Flags.String("providerType")
+			rootPath := c.Flags.String("rootPath")
+			return executor.StartBulkLoad(pegasusClient, tableName, clusterName, providerType, rootPath)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.String("c", "clusterName", "", "cluster name")
+			f.String("p", "providerType", "", "remote provider type")
+			f.String("r", "rootPath", "", "remote root path")
+		},
+	})
+
+	rootCmd.AddCommand(&grumble.Command{
+		Name:  "query",
+		Help:  "query bulk load status for a specific table or a specific partition",
+		Usage: `query <-a|--tableName TABLE_NAME> [-i|--partitionIndex PARTITION_INDEX] [-d|--detailed SHOW_DETAILED_BULK_LOAD_STATUS]`,
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			partitionIndex := c.Flags.Int("partitionIndex")
+			detailed := c.Flags.Bool("detailed")
+			return executor.QueryBulkLoad(pegasusClient, tableName, partitionIndex, detailed)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.Int("i", "partitionIndex", -1, "partition index, default value is -1, meaning show all partitions status")
+			f.Bool("d", "detailed", false, "show detailed bulk load status, default value is false")
+		},
+	})
+
+	rootCmd.AddCommand(&grumble.Command{
+		Name:  "pause",
+		Help:  "pause bulk load for a specific table",
+		Usage: "pause <-a|--tableName TABLE_NAME>",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			return executor.PauseBulkLoad(pegasusClient, tableName)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+		},
+	})
+
+	rootCmd.AddCommand(&grumble.Command{
+		Name:  "restart",
+		Help:  "restart bulk load for a specific table",
+		Usage: "restart <-a|--tableName TABLE_NAME>",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			return executor.RestartBulkLoad(pegasusClient, tableName)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+		},
+	})
+
+	rootCmd.AddCommand(&grumble.Command{
+		Name:  "cancel",
+		Help:  "cancel bulk load for a specific table",
+		Usage: "cancel <-a|--tableName TABLE_NAME> [-f|--forced FORCED]",
+		Run: func(c *grumble.Context) error {
+			if c.Flags.String("tableName") == "" {
+				return fmt.Errorf("tableName cannot be empty")
+			}
+			tableName := c.Flags.String("tableName")
+			forced := c.Flags.Bool("forced")
+			return executor.CancelBulkLoad(pegasusClient, tableName, forced)
+		},
+		Flags: func(f *grumble.Flags) {
+			/*define the flags*/
+			f.String("a", "tableName", "", "table name")
+			f.Bool("f", "forced", false, "force cancel bulk load")
+		},
+	})
+
+	shell.AddCommand(rootCmd)
+}

--- a/executor/bulk_load.go
+++ b/executor/bulk_load.go
@@ -302,7 +302,7 @@ func PrintSingleIngesting(client *Client, resp *admin.QueryBulkLoadResponse, par
 		tbWriter.SetFooter([]string{
 			fmt.Sprintf("Table(%s) Partition[%d]", resp.GetAppName(), partitionIndex),
 			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
-			fmt.Sprintf(""),
+			"",
 		})
 	}).Render()
 }
@@ -362,7 +362,7 @@ func PrintSinglePausing(client *Client, resp *admin.QueryBulkLoadResponse, parti
 		tbWriter.SetFooter([]string{
 			fmt.Sprintf("Table(%s) Partition[%d]", resp.GetAppName(), partitionIndex),
 			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
-			fmt.Sprintf(""),
+			"",
 		})
 	}).Render()
 }

--- a/executor/bulk_load.go
+++ b/executor/bulk_load.go
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"fmt"
+
+	"github.com/XiaoMi/pegasus-go-client/idl/admin"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pegasus-kv/admin-cli/tabular"
+	"github.com/pegasus-kv/admin-cli/util"
+)
+
+func StartBulkLoad(client *Client, tableName string, clusterName string, providerType string, rootPath string) error {
+	err := client.Meta.StartBulkLoad(tableName, clusterName, providerType, rootPath)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Table %s start bulk load succeed\n", tableName)
+	return nil
+}
+
+func PauseBulkLoad(client *Client, tableName string) error {
+	err := client.Meta.PauseBulkLoad(tableName)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Table %s pause bulk load succeed\n", tableName)
+	return nil
+}
+
+func RestartBulkLoad(client *Client, tableName string) error {
+	err := client.Meta.RestartBulkLoad(tableName)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Table %s restart bulk load succeed\n", tableName)
+	return nil
+}
+
+func CancelBulkLoad(client *Client, tableName string, forced bool) error {
+	err := client.Meta.CancelBulkLoad(tableName, forced)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Table %s cancel bulk load succeed\n", tableName)
+	return nil
+}
+
+func QueryBulkLoad(client *Client, tableName string, partitionIndex int, detailed bool) error {
+	resp, err := client.Meta.QueryBulkLoad(tableName)
+	if err != nil {
+		return err
+	}
+	partitionCount := len(resp.GetPartitionsStatus())
+	if partitionIndex < -1 || partitionIndex >= partitionCount {
+		return fmt.Errorf("Table %s query bulk load failed [hint: invalid partition index %d]", tableName, partitionIndex)
+	}
+	allPartitions := (partitionIndex == -1)
+	if allPartitions {
+		tableStatus := resp.GetAppStatus()
+		switch tableStatus {
+		case admin.BulkLoadStatus_BLS_DOWNLOADING:
+			PrintAllDownloading(client, resp, detailed)
+		case admin.BulkLoadStatus_BLS_SUCCEED, admin.BulkLoadStatus_BLS_FAILED, admin.BulkLoadStatus_BLS_CANCELED:
+			PrintAllCleanupFlag(client, resp, detailed)
+		default:
+			PrintAllOthers(client, resp, detailed)
+		}
+	} else {
+		partitionStatus := resp.GetPartitionsStatus()[partitionIndex]
+		switch partitionStatus {
+		case admin.BulkLoadStatus_BLS_DOWNLOADING:
+			PrintSingleDownloading(client, resp, partitionIndex, detailed)
+		case admin.BulkLoadStatus_BLS_INGESTING:
+			PrintSingleIngesting(client, resp, partitionIndex, detailed)
+		case admin.BulkLoadStatus_BLS_SUCCEED, admin.BulkLoadStatus_BLS_FAILED, admin.BulkLoadStatus_BLS_CANCELED:
+			PrintSingleCleanupFlag(client, resp, partitionIndex, detailed)
+		case admin.BulkLoadStatus_BLS_PAUSING:
+			PrintSinglePausing(client, resp, partitionIndex, detailed)
+		default:
+			PrintSingleSummary(client, resp.GetAppName(), int32(partitionIndex), resp.GetPartitionsStatus()[partitionIndex])
+		}
+	}
+	return nil
+}
+
+func PrintAllDownloading(client *Client, resp *admin.QueryBulkLoadResponse, detailed bool) {
+	// calculate download progress
+	partitionCount := len(resp.GetPartitionsStatus())
+	var totalProgress int32 = 0
+	partitionProgress := make(map[int]int32)
+	for i, stateMap := range resp.GetBulkLoadStates() {
+		var progress int32 = 0
+		for _, pState := range stateMap {
+			progress += pState.GetDownloadProgress()
+		}
+		progress /= resp.GetMaxReplicaCount()
+		partitionProgress[i] = progress
+		totalProgress += progress
+	}
+	totalProgress /= int32(partitionCount)
+	// print summary info
+	if !detailed {
+		var tList []interface{}
+		type summaryStruct struct {
+			TName    string `json:"TableName"`
+			TStatus  string `json:"TableStatus"`
+			Progress int32  `json:"TotalDownloadProgress"`
+		}
+		tList = append(tList, summaryStruct{
+			TName:    resp.GetAppName(),
+			TStatus:  resp.GetAppStatus().String(),
+			Progress: totalProgress,
+		})
+		tabular.Print(client, tList)
+		return
+	}
+	// print detailed info
+	var aList []interface{}
+	type allStruct struct {
+		Pidx     int32  `json:"PartitionIndex"`
+		Status   string `json:"PartitionStatus"`
+		Progress int32  `json:"DownloadProgress"`
+	}
+	for i := 0; i < partitionCount; i++ {
+		aList = append(aList, allStruct{
+			Pidx:     int32(i),
+			Status:   resp.GetPartitionsStatus()[i].String(),
+			Progress: partitionProgress[i],
+		})
+	}
+	tabular.New(client, aList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("Name(%s)", resp.GetAppName()),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+			fmt.Sprintf("%d", totalProgress),
+		})
+	}).Render()
+}
+
+func PrintAllOthers(client *Client, resp *admin.QueryBulkLoadResponse, detailed bool) {
+	partitionCount := len(resp.GetPartitionsStatus())
+	if !detailed {
+		PrintAllSummary(client, resp.GetAppName(), resp.GetAppStatus())
+		return
+	}
+	var aList []interface{}
+	type allStruct struct {
+		Pidx   int32  `json:"PartitionIndex"`
+		Status string `json:"PartitionStatus"`
+	}
+	for i := 0; i < partitionCount; i++ {
+		aList = append(aList, allStruct{
+			Pidx:   int32(i),
+			Status: resp.GetPartitionsStatus()[i].String(),
+		})
+	}
+	tabular.New(client, aList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("TableName(%s)", resp.GetAppName()),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+		})
+	}).Render()
+}
+
+func PrintAllCleanupFlag(client *Client, resp *admin.QueryBulkLoadResponse, detailed bool) {
+	partitionCount := len(resp.GetPartitionsStatus())
+	if !detailed {
+		PrintAllSummary(client, resp.GetAppName(), resp.GetAppStatus())
+		return
+	}
+	var aList []interface{}
+	type allStruct struct {
+		Pidx    int32  `json:"PartitionIndex"`
+		Status  string `json:"PartitionStatus"`
+		Cleanup bool   `json:"IsCleanup"`
+	}
+	tableCleanup := true
+	for i := 0; i < partitionCount; i++ {
+		partitionMap := resp.GetBulkLoadStates()[i]
+		partitionCleanup := int32(len(partitionMap)) == resp.GetMaxReplicaCount()
+		for _, state := range partitionMap {
+			partitionCleanup = partitionCleanup && state.GetIsCleanedUp()
+		}
+		aList = append(aList, allStruct{
+			Pidx:    int32(i),
+			Status:  resp.GetPartitionsStatus()[i].String(),
+			Cleanup: partitionCleanup,
+		})
+		tableCleanup = tableCleanup && partitionCleanup
+	}
+	tabular.New(client, aList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("TableName(%s)", resp.GetAppName()),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+			fmt.Sprintf("%v", tableCleanup),
+		})
+	}).Render()
+}
+
+func PrintAllSummary(client *Client, tableName string, tableStatus admin.BulkLoadStatus) {
+	var tList []interface{}
+	type summaryStruct struct {
+		TName   string `json:"TableName"`
+		TStatus string `json:"TableStatus"`
+	}
+	tList = append(tList, summaryStruct{
+		TName:   tableName,
+		TStatus: tableStatus.String(),
+	})
+	tabular.Print(client, tList)
+}
+
+func PrintSingleDownloading(client *Client, resp *admin.QueryBulkLoadResponse, partitionIndex int, detailed bool) {
+	stateMap := resp.GetBulkLoadStates()[partitionIndex]
+	var partitionProgress int32 = 0
+	for _, state := range stateMap {
+		partitionProgress += state.GetDownloadProgress()
+	}
+	partitionProgress /= resp.GetMaxReplicaCount()
+	// print summary info
+	if !detailed {
+		var tList []interface{}
+		type summaryStruct struct {
+			TName    string `json:"TableName"`
+			Pidx     int32  `json:"Pidx"`
+			PStatus  string `json:"PartitionStatus"`
+			Progress int32  `json:"DownloadProgress"`
+		}
+		tList = append(tList, summaryStruct{
+			TName:    resp.GetAppName(),
+			Pidx:     int32(partitionIndex),
+			PStatus:  resp.GetPartitionsStatus()[partitionIndex].String(),
+			Progress: partitionProgress,
+		})
+		tabular.Print(client, tList)
+		return
+	}
+	// print detailed info
+	var sList []interface{}
+	type singleStruct struct {
+		Node     string `json:"NodeAddress"`
+		PStatus  string `json:"PartitionStatus"`
+		Progress int32  `json:"DownloadProgress"`
+	}
+	for node, state := range stateMap {
+		sList = append(sList, singleStruct{
+			Node:     node.String(),
+			PStatus:  resp.GetPartitionsStatus()[partitionIndex].String(),
+			Progress: state.GetDownloadProgress(),
+		})
+	}
+	util.SortStructsByField(sList, "Node")
+	tabular.New(client, sList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("Table(%s) Partition[%d]", resp.GetAppName(), partitionIndex),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+			fmt.Sprintf("%d", partitionProgress),
+		})
+	}).Render()
+}
+
+func PrintSingleIngesting(client *Client, resp *admin.QueryBulkLoadResponse, partitionIndex int, detailed bool) {
+	stateMap := resp.GetBulkLoadStates()[partitionIndex]
+	if !detailed {
+		PrintSingleSummary(client, resp.GetAppName(), int32(partitionIndex), resp.GetPartitionsStatus()[partitionIndex])
+		return
+	}
+	var sList []interface{}
+	type singleStruct struct {
+		Node    string `json:"NodeAddress"`
+		PStatus string `json:"PartitionStatus"`
+		IStatus string `json:"IngestionStatus"`
+	}
+	for node, state := range stateMap {
+		sList = append(sList, singleStruct{
+			Node:    node.String(),
+			PStatus: resp.GetPartitionsStatus()[partitionIndex].String(),
+			IStatus: state.GetIngestStatus().String(),
+		})
+	}
+	util.SortStructsByField(sList, "Node")
+	tabular.New(client, sList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("Table(%s) Partition[%d]", resp.GetAppName(), partitionIndex),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+			fmt.Sprintf(""),
+		})
+	}).Render()
+}
+
+func PrintSingleCleanupFlag(client *Client, resp *admin.QueryBulkLoadResponse, partitionIndex int, detailed bool) {
+	stateMap := resp.GetBulkLoadStates()[partitionIndex]
+	if !detailed {
+		PrintSingleSummary(client, resp.GetAppName(), int32(partitionIndex), resp.GetPartitionsStatus()[partitionIndex])
+		return
+	}
+	var sList []interface{}
+	type singleStruct struct {
+		Node    string `json:"NodeAddress"`
+		PStatus string `json:"PartitionStatus"`
+		Cleanup bool   `json:"IsCleanup"`
+	}
+	isCleanup := true
+	for node, state := range stateMap {
+		sList = append(sList, singleStruct{
+			Node:    node.String(),
+			PStatus: resp.GetPartitionsStatus()[partitionIndex].String(),
+			Cleanup: state.GetIsCleanedUp(),
+		})
+		isCleanup = isCleanup && state.GetIsCleanedUp()
+	}
+	util.SortStructsByField(sList, "Node")
+	tabular.New(client, sList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("Table(%s) Partition[%d]", resp.GetAppName(), partitionIndex),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+			fmt.Sprintf("%v", isCleanup),
+		})
+	}).Render()
+}
+
+func PrintSinglePausing(client *Client, resp *admin.QueryBulkLoadResponse, partitionIndex int, detailed bool) {
+	stateMap := resp.GetBulkLoadStates()[partitionIndex]
+	if !detailed {
+		PrintSingleSummary(client, resp.GetAppName(), int32(partitionIndex), resp.GetPartitionsStatus()[partitionIndex])
+		return
+	}
+	var sList []interface{}
+	type singleStruct struct {
+		Node    string `json:"NodeAddress"`
+		PStatus string `json:"PartitionStatus"`
+		Paused  bool   `json:"IsPaused"`
+	}
+	for node, state := range stateMap {
+		sList = append(sList, singleStruct{
+			Node:    node.String(),
+			PStatus: resp.GetPartitionsStatus()[partitionIndex].String(),
+			Paused:  state.GetIsPaused(),
+		})
+	}
+	util.SortStructsByField(sList, "Node")
+	tabular.New(client, sList, func(tbWriter *tablewriter.Table) {
+		tbWriter.SetFooter([]string{
+			fmt.Sprintf("Table(%s) Partition[%d]", resp.GetAppName(), partitionIndex),
+			fmt.Sprintf("Table(%s)", resp.GetAppStatus().String()),
+			fmt.Sprintf(""),
+		})
+	}).Render()
+}
+
+func PrintSingleSummary(client *Client, tableName string, pidx int32, partitionStatus admin.BulkLoadStatus) {
+	var tList []interface{}
+	type summaryStruct struct {
+		TName   string `json:"TableName"`
+		Pidx    int32  `json:"Pidx"`
+		PStatus string `json:"PartitionStatus"`
+	}
+	tList = append(tList, summaryStruct{
+		TName:   tableName,
+		Pidx:    pidx,
+		PStatus: partitionStatus.String(),
+	})
+	tabular.Print(client, tList)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pegasus-kv/admin-cli
 go 1.14
 
 require (
-	github.com/XiaoMi/pegasus-go-client v0.0.0-20210918053547-2a615cf30133
+	github.com/XiaoMi/pegasus-go-client v0.0.0-20211013054553-ae3787ff8253
 	github.com/cheggaaa/pb/v3 v3.0.6
 	github.com/desertbit/grumble v1.1.1
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/XiaoMi/pegasus-go-client v0.0.0-20201127155445-d3b9a03abf6e/go.mod h1:H83dStz3HvHBFC0n7QK+qLHAjqsIghFOFx2TCvq6vzI=
-github.com/XiaoMi/pegasus-go-client v0.0.0-20210918053547-2a615cf30133 h1:ApdHWACFRB8Bzo5iuBj1yd4sC2Yecg4j6Ip+i7vjGXs=
-github.com/XiaoMi/pegasus-go-client v0.0.0-20210918053547-2a615cf30133/go.mod h1:VrfgKISflRhFm32m3e0SXLccvNJTyG8PRywWbUuGEfY=
+github.com/XiaoMi/pegasus-go-client v0.0.0-20211013054553-ae3787ff8253 h1:Ho1oXfP+K58rWtj1g+NvP79ADOn9OBw7yY7snik5M/A=
+github.com/XiaoMi/pegasus-go-client v0.0.0-20211013054553-ae3787ff8253/go.mod h1:VrfgKISflRhFm32m3e0SXLccvNJTyG8PRywWbUuGEfY=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
 github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=


### PR DESCRIPTION
This pull request support bulk load related commands, including: start, query, pause, restart and cancel.
The test result by onebox is like below:
## start bulk load
```
Pegasus-AdminCli-1.1.0 » bulk-load start -a temp -c cluster -p local_service -r bulk_load_root
Table temp start bulk load succeed
```
## pause bulk load
```
Pegasus-AdminCli-1.1.0 » bulk-load pause -a temp
Table temp pause bulk load succeed
```
## restart bulk load
```
Pegasus-AdminCli-1.1.0 » bulk-load restart -a temp
Table temp restart bulk load succeed
```
## cancel bulk load
```
Pegasus-AdminCli-1.1.0 » bulk-load cancel -a temp
Table temp cancel bulk load succeed
```
## query bulk load
### query all partitions detailed status
```
Pegasus-AdminCli-1.1.0 » bulk-load query -a temp -d
+----------------+------------------------+------------------+
| PartitionIndex |    PartitionStatus     | DownloadProgress |
+----------------+------------------------+------------------+
| 0              | BLS_DOWNLOADING        | 33               |
| 1              | BLS_DOWNLOADING        | 33               |
| 2              | BLS_DOWNLOADING        | 33               |
| 3              | BLS_DOWNLOADING        | 33               |
| 4              | BLS_DOWNLOADING        | 33               |
| 5              | BLS_DOWNLOADING        | 33               |
| 6              | BLS_DOWNLOADING        | 33               |
| 7              | BLS_DOWNLOADING        | 33               |
+----------------+------------------------+------------------+
|   Name(temp)   | Table(BLS_DOWNLOADING) |        33        |
+----------------+------------------------+------------------+
```
### query single partition detailed status
```
Pegasus-AdminCli-1.1.0 » bulk-load query -a temp -d -i 4
+---------------------------------+----------------------+-----------------+
|           NodeAddress           |   PartitionStatus    | IngestionStatus |
+---------------------------------+----------------------+-----------------+
| RPCAddress(ip1:port1)           | BLS_INGESTING        | IS_RUNNING      |
| RPCAddress(ip2:port2)           | BLS_INGESTING        | IS_INVALID      |
| RPCAddress(ip3:port3)           | BLS_INGESTING        | IS_INVALID      |
+---------------------------------+----------------------+-----------------+
|    Table(temp) Partition[4]     | Table(BLS_INGESTING) |                  
+---------------------------------+----------------------+-----------------+

```
### query all partitions summary status
```
Pegasus-AdminCli-1.1.0 » bulk-load query -a temp
+-----------+--------------+
| TableName | TableStatus  |
+-----------+--------------+
| temp      | BLS_CANCELED |
+-----------+--------------+
```
### query single partition summary status
```
Pegasus-AdminCli-1.1.0 » bulk-load query -a temp -i 5
+-----------+------+-----------------+
| TableName | Pidx | PartitionStatus |
+-----------+------+-----------------+
| temp      | 5    | BLS_SUCCEED     |
+-----------+------+-----------------+
```